### PR TITLE
Search

### DIFF
--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -2,6 +2,7 @@
 search bar and to collect and filter parameter options. -->
 
 <script>
+import _ from 'lodash';
 import {
   FileManager as GirderFileManager
 } from '@girder/components/src/components/Snippet';

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -128,12 +128,12 @@ export default {
       this.$parent.$parent.$parent.$parent.$emit(
         "param-selected", item.data[0]._id, name, e);
     },
-    async getFilteredResults() {
+    getFilteredResults:  _.debounce(async function(event) {
       let input = this.input ? this.input : '';
       let { data } = await this.girderRest.get(
         `resource/${this.location._id}/search?type=folder&q=${input}`);
       this.filteredItems = data.results;
-    },
+    }, 500),
   },
 };
 </script>

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -2,7 +2,9 @@
 search bar and to collect and filter parameter options. -->
 
 <script>
-import { FileManager as GirderFileManager } from '@girder/components/src/components/Snippet';
+import {
+  FileManager as GirderFileManager
+} from '@girder/components/src/components/Snippet';
 import GirderDataBrowser from './GirderDataBrowser.vue';
 import {
   Breadcrumb as GirderBreadcrumb,
@@ -31,7 +33,7 @@ export default {
   computed: {
     queryValues: {
       get () {
-        if (this.query && this.query.hasOwnProperty('value') && !this.showPartials) {
+        if (this.query && _.has(this.query, 'value') && !this.showPartials) {
           return [this.query.value];
         }
         else if (this.showPartials && this.filteredItems) {
@@ -53,14 +55,15 @@ export default {
 
   watch: {
     async query() {
-      if (this.input === '' || this.input && !typeof(this.query) == 'object'){
+      if (this.$refs.query.isFocused && !(_.isObject(this.query))){
         this.showPartials = true;
-      } else if (typeof(this.query) == 'object') {
+      } else if (_.isObject(this.query)) {
         this.showPartials = false;
       }
       this.refresh();
-      if (!this.showPartials && typeof(this.query) == 'object') {
-        let { data } = await this.girderRest.get(`/folder/${this.query.value.folderId}`);
+      if (!this.showPartials && _.isObject(this.query)) {
+        let { data } = await this.girderRest.get(
+          `/folder/${this.query.value.folderId}`);
         this.internalLocation = {...data, 'search': true};
       }
     },
@@ -68,7 +71,7 @@ export default {
       this.refresh();
     },
     input() {
-      if (this.input == '') {
+      if (_.isEmpty(this.input)) {
         this.clear();
       }
     },
@@ -86,7 +89,7 @@ export default {
       var location = this.lazyLocation ? this.lazyLocation : this.location;
 
       this.currentPath = '';
-      if (location.hasOwnProperty('_id')) {
+      if (_.has(location, '_id')) {
         let { data } = await this.girderRest.get(
           `/resource/${location._id}/path?type=${location._modelType}`);
         this.currentPath = data;
@@ -109,7 +112,8 @@ export default {
       this.refresh();
     },
     showMatches() {
-      if (this.query == this.input) {
+      if (_.isEqual(this.query, this.input) ||
+            (_.isNull(this.query) && _.isEmpty(this.input))) {
         this.showPartials = true;
       }
       if (this.$refs.query.isMenuActive) {
@@ -118,8 +122,10 @@ export default {
     },
     async fetchMovie(e) {
       let name = e.target.textContent.trim();
-      var item = await this.girderRest.get(`/item?folderId=${this.location._id}&name=${name}`);
-      this.$parent.$parent.$parent.$parent.$emit("param-selected", item.data[0]._id, name, e);
+      var item = await this.girderRest.get(
+        `/item?folderId=${this.location._id}&name=${name}`);
+      this.$parent.$parent.$parent.$parent.$emit(
+        "param-selected", item.data[0]._id, name, e);
     },
     async getFilteredResults() {
       let input = this.input ? this.input : '';

--- a/girder/esimmon_plugin/esimmon_plots/__init__.py
+++ b/girder/esimmon_plugin/esimmon_plots/__init__.py
@@ -1,0 +1,10 @@
+from girder.plugin import GirderPlugin
+
+from .esimmonfile import find_parameters
+
+
+class ESimMonPlugin(GirderPlugin):
+  DISPLAY_NAME = 'ESimMon Plugin'
+
+  def load(self, info):
+    info['apiRoot'].resource.route('GET', (':id', 'search'), find_parameters)

--- a/girder/esimmon_plugin/esimmon_plots/__init__.py
+++ b/girder/esimmon_plugin/esimmon_plots/__init__.py
@@ -1,10 +1,10 @@
 from girder.plugin import GirderPlugin
 
-from .esimmonfile import find_parameters
+from .esimmonfile import find_items
 
 
 class ESimMonPlugin(GirderPlugin):
-  DISPLAY_NAME = 'ESimMon Plugin'
+  DISPLAY_NAME = 'eSimMon Plugin'
 
   def load(self, info):
-    info['apiRoot'].resource.route('GET', (':id', 'search'), find_parameters)
+    info['apiRoot'].resource.route('GET', (':id', 'search'), find_items)

--- a/girder/esimmon_plugin/esimmon_plots/esimmonfile.py
+++ b/girder/esimmon_plugin/esimmon_plots/esimmonfile.py
@@ -1,0 +1,49 @@
+import
+from girder.api import access
+from girder.api.describe import Description, autoDescribeRoute
+from girder.api.rest import getCurrentUser
+
+from girder.utility.path import getResourcePath
+
+from girder.models.collection import Collection
+from girder.models.folder import Folder
+
+def _filter_items(folders, user, query, matches, parent):
+    for folder in folders:
+        if not
+        items = list(Folder().childItems(folder, parentType='folder', user=user))
+        for item in items:
+            full_path = getResourcePath('item', item, user)
+            trimmed_path = full_path.split(parent['name'])[1]
+            if query in trimmed_path:
+                matches.append({'text': trimmed_path, 'value': item})
+        folders = list(Folder().childFolders(folder, parentType='folder', user=user))
+        if folders:
+            _filter_items(folders, user, query, matches, parent)
+    return matches
+
+@access.public
+@autoDescribeRoute(
+  Description('Search for items that are children of the given resource.')
+  .param('id', 'The ID of the resource.', paramType='path')
+  .param('type', 'The type of the resource (must be collection or folder).')
+  .param('q', 'The search query.', dataType='string', required=False)
+)
+def find_parameters(id, type, q):
+    user = getCurrentUser()
+    if type == 'collection':
+        resource = Collection().load(id, user=user)
+        if resource is None:
+            raise RestException('Invalid resource id.')
+        folders = list(Folder().childFolders(resource, parentType=type, user=user))
+    elif type == 'folder':
+        resource = Folder().load(id, user=user)
+        if resource is None:
+            raise RestException('Invalid resource id.')
+        folders = [resource]
+    else:
+        raise RestException('Parent must be a collection or folder.')
+
+    results = _filter_items(folders, user, q, [], resource)
+
+    return {'results': results}

--- a/girder/esimmon_plugin/esimmon_plots/esimmonfile.py
+++ b/girder/esimmon_plugin/esimmon_plots/esimmonfile.py
@@ -27,7 +27,7 @@ def _filter_items(folders, user, query, matches, parent):
   .param('type', 'The type of the resource (must be collection or folder).')
   .param('q', 'The search query.', dataType='string', required=False)
 )
-def find_parameters(id, type, q):
+def find_items(id, type, q):
     user = getCurrentUser()
     if type == 'collection':
         resource = Collection().load(id, user=user)

--- a/girder/esimmon_plugin/esimmon_plots/esimmonfile.py
+++ b/girder/esimmon_plugin/esimmon_plots/esimmonfile.py
@@ -1,4 +1,3 @@
-import
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import getCurrentUser
@@ -10,7 +9,6 @@ from girder.models.folder import Folder
 
 def _filter_items(folders, user, query, matches, parent):
     for folder in folders:
-        if not
         items = list(Folder().childItems(folder, parentType='folder', user=user))
         for item in items:
             full_path = getResourcePath('item', item, user)

--- a/girder/esimmon_plugin/setup.py
+++ b/girder/esimmon_plugin/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='esimmon-plugin',
     version='0.0.1',
-    description='Finds items matching search parameters.',
+    description='Provide endpoints to support eSimMon dashboard.',
     packages=find_packages(),
     install_requires=[
       'girder>=3.0.0'

--- a/girder/esimmon_plugin/setup.py
+++ b/girder/esimmon_plugin/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='esimmon-plugin',
+    version='0.0.1',
+    description='Finds items matching search parameters.',
+    packages=find_packages(),
+    install_requires=[
+      'girder>=3.0.0'
+    ],
+    entry_points={
+      'girder.plugin': [
+          'esimmon_plugin = esimmon_plots:ESimMonPlugin'
+      ]
+    }
+)


### PR DESCRIPTION
This PR adds a new endpoint so that the searching and filtering can be done server-side. The new endpoint is `/resource/{id}/search`, which takes in the `id` and `type` of the current location, as well as `query` parameters if there are any. Any empty search will return all items in the sub-tree. If search parameters are provided the entire relative path is searched as well as the item (parameter) name.

On the client side the search behavior should behave the same as originally described in #37.

Addresses the improvements mentioned in #19