### PR TITLE
Add a horizontal scroll bar for the left nav panel

### DIFF
--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -55,23 +55,24 @@
 // and shows a scrollbar when necessary.
 .girder-data-browser-snippet {
   flex-grow: 1;
-  max-height: calc(100% - 175px);
+  min-height: 80%;
   overflow: auto;
 }
 .girder-placeholder {
   flex-grow: 1;
-  max-height: calc(100% - 175px);
+  min-height: 80%;
 }
 
 // Playback controls take up 20% of the left column.
 .playback-controls {
-  display: grid;
-  max-height: 200px;
-  min-height: 175px;
-  padding: 10px 5px;
-  overflow-x: scroll;
+  display: flex;
+  flex-flow: column;
+  max-height: 20%;
+  overflow: auto;
+  padding: 5px;
   .row {
     justify-content: space-around;
+    align-items: baseline;
     margin: 0;
     padding: 1%;
     .col {

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -69,6 +69,7 @@
   max-height: 200px;
   min-height: 175px;
   padding: 10px 5px;
+  overflow-x: scroll;
   .row {
     justify-content: space-around;
     margin: 0;


### PR DESCRIPTION
This seems to be working for me, but even when I was collapsing the window down it was impossible for me to get the controls to be completely hidden. Nonetheless I was able to get a vertical scroll when the window and panel were shrunk down now, hopefully this solves the problem.

Fixes #65