### PR TITLE
Create docker-compose for standalone watch service

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Bringing up the stack will create a series of Docker containers that allow the u
 - ```docker-compose.ansible.yml``` - Ansible playbook to setup the Girder instance. The playbook will create two users (one with admin rights), an assetstore for storage, a collection for the data, a folder within that collection that will be the default location to upload the data to (this can be changed with the ```GIRDER_FOLDER_ID``` discussed in the section below), and the API key that the ```watch``` container will need.
 - ```docker-compose.client.yml``` - Builds the client application and uses NGINX to make the app available on ```localhost:9090```.
 - ```docker-compose.watch.yml``` - Runs a Python script to watch the simulation assets site (where the data is being hosted) and upload that data to Girder as it comes in.
+- ```docker-compose.watch-standalone.yml``` - Runs the same monitoring code as ```docker-compose.watch.yml```, but does not require that the ```Girder``` container be run as well. Used to run the monitoring service outside of the stack.
 - ```docker-compose.movie.yml``` - A Flask service that uses FFmpeg to create movies of the selected parameter's data, then downloads them to the local machine.
 - ```docker-compose.demo.yml``` - A static simulation assets site that has been pre-populated with sample data and can be used as a simple way to populate and interact with the dashboard. This is set to be the default ```UPLOAD_SITE_URL```, which is what the ingest script in the ```watch``` container will watch for new data.
 
@@ -57,7 +58,7 @@ In order to run the watch service outside of the stack, the following environmen
 The container can then be brought up with docker-compose:
 
     cd <repo>/devops/docker
-    docker-compose -p esimmon -f docker-compose.watch.yml up
+    docker-compose -p esimmon -f docker-compose.watch-standalone.yml up
 
 If the container starts up successfully you should see the following message at the very beginning, showing that the upload site set in the ```UPLOAD_SITE_URL``` is being watched for updates:
 

--- a/devops/docker/docker-compose.watch-standalone.yml
+++ b/devops/docker/docker-compose.watch-standalone.yml
@@ -8,4 +8,3 @@ services:
     command: "watch -i 60 -v 60"
     env_file:
       - watch.env
-    entrypoint: ["/wait-for-it.sh", "girder:8080", "-t", "30", "--", "/usr/local/bin/adash"]

--- a/devops/docker/ingest/Dockerfile
+++ b/devops/docker/ingest/Dockerfile
@@ -4,5 +4,6 @@ COPY ./ingest /ingest
 
 RUN pip install /ingest
 
-CMD ["../docker/wait-for-it.sh", "girder:8080", "-t", "30"]
+COPY ./devops/docker/wait-for-it.sh /wait-for-it.sh
+
 ENTRYPOINT ["/usr/local/bin/adash"]


### PR DESCRIPTION
If the monitoring service is being run in the stack, use a docker-compose `entrypoint` to wait until Girder is available. If it is being separately, do not wait.