### PR TITLE
Mount the assetstore in the correct location

### DIFF
--- a/devops/ansible/site.yml
+++ b/devops/ansible/site.yml
@@ -37,7 +37,7 @@
         assetstore:
           name: "Filesystem Assetstore"
           type: "filesystem"
-          root: "/assetstore"
+          root: "/data/assetstore"
           current: true
         state: present
 


### PR DESCRIPTION
This fixes a bug that made the assetstore unavailable after the stack was brought down since the volume path did not match the root path being set by the Ansible playbook.