### PR TITLE
Handle the case of no first time step

### DIFF
--- a/client/src/components/ImageGallery.vue
+++ b/client/src/components/ImageGallery.vue
@@ -173,6 +173,11 @@ export default {
           idx = this.rows.findIndex(file => file.step === prevStep);
           prevStep -= 1;
         }
+        let nextStep = this.step + 1;
+        while (nextStep <= this.maxTimeStep && idx < 0) {
+          idx = this.rows.findIndex(file => file.step === nextStep);
+          nextStep += 1;
+        }
       }
       // Load the current image and the next two.
       var any_images_loaded = false;


### PR DESCRIPTION
If there is no data available for the current or any previous time steps, then use the data for the next available time step.