### PR TITLE
Girder plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw*
+
+# ECS Params files
+ecs-params.*.yml

--- a/devops/docker/girder/Dockerfile
+++ b/devops/docker/girder/Dockerfile
@@ -8,5 +8,6 @@ COPY girder /plugin/
 # Otherwise we run into issues with the load balancer on AWS
 RUN pip3 install -U CherryPy==18.6.0 cheroot==8.4.2
 
+RUN pip3 install girder-autojoin
 # Install eSimMon plugin
 RUN pip3 install -e /plugin/esimmon_plugin


### PR DESCRIPTION
Add the `autojoin` plugin in order to automatically assign users to groups in Girder.