### PR TITLE
Private views

### DIFF
--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -361,7 +361,7 @@ export default {
               name,
               this.numrows,
               this.numcols,
-              currentTimeStep,
+              this.currentTimeStep,
               false);
             // Check if default view already exists
             const { data } = await this.girderRest.get(

--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -51,9 +51,9 @@ export default {
       showRangeDialog: false,
       run_id: undefined,
       simulation: undefined,
-      defaultView: null,
+      autoSavedView: null,
       lastSaved: '',
-      loadDefaultViewDialog: false,
+      loadAutoSavedViewDialog: false,
       viewGrid: null,
     };
   },
@@ -375,7 +375,7 @@ export default {
               this.numcols,
               this.currentTimeStep,
               false);
-            // Check if default view already exists
+            // Check if auto-saved view already exists
             const { data } = await this.girderRest.get(
               `/view?text=${name}&exact=true&limit=50&sort=name&sortdir=1`);
             if (data.length) {
@@ -403,10 +403,10 @@ export default {
       this.simulation = data[simulationIdx].object._id;
     },
 
-    loadDefaultView() {
-      this.viewSelected(this.defaultView);
-      this.defaultView = null;
-      this.loadDefaultViewDialog = false;
+    loadAutoSavedView() {
+      this.viewSelected(this.autoSavedView);
+      this.autoSavedView = null;
+      this.loadAutoSavedViewDialog = false;
     }
   },
 
@@ -485,8 +485,8 @@ export default {
           `/view?text=${viewName}&exact=true&limit=50&sort=name&sortdir=1`)
         const view = data[0]
         if (view) {
-          this.loadDefaultViewDialog = true;
-          this.defaultView = view;
+          this.loadAutoSavedViewDialog = true;
+          this.autoSavedView = view;
         }
       }
     }

--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -159,20 +159,25 @@ export default {
 
     initialDataLoaded(num_timesteps, itemId) {
       this.numLoadedGalleries += 1;
-      if (this.dataLoaded) {
-        return;
+      if (!this.dataLoaded) {
+        this.dataLoaded = true;
+        this.maxTimeStep = num_timesteps;
+
+        // Setup polling to watch for new data.
+        this.poll(itemId);
+
+        // Setup polling to autosave view
+        this.autosave();
+
+        // Default to playing once a parameter has been selected
+        this.togglePlayPause();
       }
-      this.dataLoaded = true;
-      this.maxTimeStep = num_timesteps;
 
-      // Setup polling to watch for new data.
-      this.poll(itemId);
-
-      // Setup polling to autosave view
-      this.autosave();
-
-      // Default to playing once a parameter has been selected
-      this.togglePlayPause();
+      if (this.view) {
+        this.currentTimeStep = parseInt(this.view.step, 10);
+        this.paused = true;
+        this.view = null;
+      }
     },
 
     lookupRunId(itemId) {
@@ -307,8 +312,9 @@ export default {
 
     viewSelected(view) {
       this.view = view;
-      const cols = parseInt(view.columns, 10)
-      const rows = parseInt(view.rows, 10)
+      const cols = parseInt(view.columns, 10);
+      const rows = parseInt(view.rows, 10);
+      this.numLoadedGalleries = 0;
 
       if (this.numcols !== cols) {
         this.setColumns(cols);
@@ -316,15 +322,12 @@ export default {
       if (this.numrows !== rows) {
         this.setRows(rows);
       }
-    },
-
-    imageGalleryCreated() {
       if (this.view) {
         this.$refs.imageGallery.forEach((cell) => {
           const { row, col } = cell.$attrs;
-          cell.itemId = this.view.items[`${row}::${col}`]
+          cell.itemId = this.view.items[`${row}::${col}`];
+          cell.initialLoad = true;
         });
-        this.view = null;
       }
     },
 
@@ -391,6 +394,7 @@ export default {
     this.$on('gallery-mounted', this.imageGalleryCreated);
     this.$on('view-selected', this.viewSelected);
     this.$on('range-updated', this.setGlobalRange);
+    this.$on('pause-gallery', () => {this.paused = true});
   },
 
   asyncComputed: {

--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -369,11 +369,13 @@ export default {
           if (this.autosave_run) {
             const userId = this.girderRest.user._id;
             const name = `${this.simulation}_${this.run_id}_${userId}`;
+            const meta = {simulation: this.simulation, run: this.run_id};
             const formData = saveLayout(
               this.$refs.imageGallery,
               name,
               this.numrows,
               this.numcols,
+              meta,
               this.currentTimeStep,
               false);
             // Check if auto-saved view already exists

--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -54,6 +54,7 @@ export default {
       defaultView: null,
       lastSaved: '',
       loadDefaultViewDialog: false,
+      viewGrid: null,
     };
   },
 
@@ -178,6 +179,7 @@ export default {
         this.currentTimeStep = parseInt(this.view.step, 10);
         this.paused = true;
         this.view = null;
+        this.viewGrid = null;
       }
     },
 
@@ -316,6 +318,7 @@ export default {
       const cols = parseInt(view.columns, 10);
       const rows = parseInt(view.rows, 10);
       this.numLoadedGalleries = 0;
+      this.viewGrid = cols * rows;
 
       if (this.numcols !== cols) {
         this.setColumns(cols);
@@ -323,7 +326,11 @@ export default {
       if (this.numrows !== rows) {
         this.setRows(rows);
       }
-      if (this.view) {
+      this.applyView();
+    },
+
+    applyView() {
+      if (this.$refs.imageGallery.length === this.viewGrid) {
         this.$refs.imageGallery.forEach((cell) => {
           const { row, col } = cell.$attrs;
           cell.itemId = this.view.items[`${row}::${col}`];
@@ -407,11 +414,11 @@ export default {
     this.$on('data-loaded', this.initialDataLoaded);
     this.$on('gallery-ready', this.incrementReady);
     this.$on('param-selected', this.contextMenu);
-    this.$on('gallery-mounted', this.imageGalleryCreated);
     this.$on('view-selected', this.viewSelected);
     this.$on('range-updated', this.setGlobalRange);
     this.$on('pause-gallery', () => {this.paused = true});
     this.$on('item-added', this.setRun);
+    this.$on('gallery-mounted', this.applyView);
   },
 
   asyncComputed: {

--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -359,7 +359,8 @@ export default {
       this._autosave = setTimeout(async () => {
         try {
           if (this.run_id && this.simulation) {
-            const name = `${this.simulation}_${this.run_id}_default`;
+            const userId = this.girderRest.user._id;
+            const name = `${this.simulation}_${this.run_id}_${userId}_default`;
             const formData = saveLayout(
               this.$refs.imageGallery,
               name,
@@ -471,7 +472,8 @@ export default {
         // This is a run folder. Check for default view to load.
         const simulation = grandparent._id;
         const run = parent._id;
-        const viewName = `${simulation}_${run}_default`;
+        const userId = this.girderRest.user._id;
+        const viewName = `${simulation}_${run}_${userId}_default`;
         const { data } = await this.girderRest.get(
           `/view?text=${viewName}&exact=true&limit=50&sort=name&sortdir=1`)
         const view = data[0]

--- a/client/src/components/core/App/template.html
+++ b/client/src/components/core/App/template.html
@@ -119,6 +119,7 @@
               :numrows.sync="numrows"
               :numcols.sync="numcols"
               :lastSaved.sync="lastSaved"
+              :step.sync="currentTimeStep"
             >
           </v-container>
         </v-col>

--- a/client/src/components/core/App/template.html
+++ b/client/src/components/core/App/template.html
@@ -173,4 +173,15 @@
       Movie Generation Failed
     </v-snackbar>
   </div>
+  <v-dialog v-model="loadDefaultViewDialog" persistent max-width="300">
+    <v-card>
+      <v-card-title class="headline">Load default view?</v-card-title>
+      <v-card-text>A default view has been found for this run. Would you like to load it now?</v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn text @click.stop="loadDefaultViewDialog = false">Cancel</v-btn>
+        <v-btn text @click.stop="loadDefaultView">Load View</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </v-app>

--- a/client/src/components/core/App/template.html
+++ b/client/src/components/core/App/template.html
@@ -118,6 +118,7 @@
               :imageGallery.sync="$refs.imageGallery"
               :numrows.sync="numrows"
               :numcols.sync="numcols"
+              :lastSaved.sync="lastSaved"
             >
           </v-container>
         </v-col>

--- a/client/src/components/core/App/template.html
+++ b/client/src/components/core/App/template.html
@@ -173,14 +173,14 @@
       Movie Generation Failed
     </v-snackbar>
   </div>
-  <v-dialog v-model="loadDefaultViewDialog" persistent max-width="300">
+  <v-dialog v-model="loadAutoSavedViewDialog" persistent max-width="300">
     <v-card>
-      <v-card-title class="headline">Load default view?</v-card-title>
-      <v-card-text>A default view has been found for this run. Would you like to load it now?</v-card-text>
+      <v-card-title class="headline">Load auto-saved view?</v-card-title>
+      <v-card-text>An auto-saved view has been found for this run. Would you like to load it now?</v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn text @click.stop="loadDefaultViewDialog = false">Cancel</v-btn>
-        <v-btn text @click.stop="loadDefaultView">Load View</v-btn>
+        <v-btn text @click.stop="loadAutoSavedViewDialog = false">Cancel</v-btn>
+        <v-btn text @click.stop="loadAutoSavedView">Load View</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/client/src/components/core/App/template.html
+++ b/client/src/components/core/App/template.html
@@ -120,6 +120,8 @@
               :numcols.sync="numcols"
               :lastSaved.sync="lastSaved"
               :step.sync="currentTimeStep"
+              :simulation.sync="simulation"
+              :run.sync="run_id"
             >
           </v-container>
         </v-col>

--- a/client/src/components/core/ViewControls/script.js
+++ b/client/src/components/core/ViewControls/script.js
@@ -13,7 +13,7 @@ export default {
     return {
       showSaveDialog: false,
       showLoadDialog: false,
-      viewNames: [],
+      viewInfo: {},
     };
   },
 
@@ -57,10 +57,10 @@ export default {
       await this.girderRest.get('/view')
         .then(({ data }) => {
           this.views = data;
-          this.viewNames = [];
+          this.viewInfo = {};
           data.forEach((view) => {
-            if (this.viewCreatedByUser(view) || view.public) {
-              this.viewNames.push(view.name);
+            if (this.viewCreatedByUser(view)) {
+              this.viewInfo[view.name] = view._id;
             }
           });
         })

--- a/client/src/components/core/ViewControls/script.js
+++ b/client/src/components/core/ViewControls/script.js
@@ -30,6 +30,10 @@ export default {
       type: Number,
       default: 1,
     },
+    lastSaved: {
+      type: String,
+      default: '',
+    },
   },
 
   created: async function () {
@@ -43,7 +47,9 @@ export default {
           this.views = data;
           this.viewNames = [];
           data.forEach((view) => {
-            this.viewNames.push(view.name);
+            if (this.viewCreatedByUser(view) || view.public) {
+              this.viewNames.push(view.name);
+            }
           });
         })
         .catch((error) => {
@@ -57,6 +63,9 @@ export default {
     async loadView() {
       await this.getViews();
       this.showLoadDialog = true;
-    },    
+    },
+    viewCreatedByUser(item) {
+      return this.girderRest.user._id === item.creatorId;
+    }
   },
 };

--- a/client/src/components/core/ViewControls/script.js
+++ b/client/src/components/core/ViewControls/script.js
@@ -34,6 +34,10 @@ export default {
       type: String,
       default: '',
     },
+    step: {
+      type: Number,
+      default: 1,
+    },
   },
 
   created: async function () {

--- a/client/src/components/core/ViewControls/script.js
+++ b/client/src/components/core/ViewControls/script.js
@@ -63,6 +63,7 @@ export default {
     async saveView() {
       await this.getViews();
       this.showSaveDialog = true;
+      this.$root.$children[0].$emit("pause-gallery");
     },
     async loadView() {
       await this.getViews();

--- a/client/src/components/core/ViewControls/script.js
+++ b/client/src/components/core/ViewControls/script.js
@@ -38,6 +38,14 @@ export default {
       type: Number,
       default: 1,
     },
+    simulation: {
+      type: String,
+      default: '',
+    },
+    run: {
+      type: String,
+      default: '',
+    },
   },
 
   created: async function () {
@@ -71,6 +79,12 @@ export default {
     },
     viewCreatedByUser(item) {
       return this.girderRest.user._id === item.creatorId;
+    }
+  },
+
+  computed: {
+    meta() {
+      return { simulation: this.simulation, run: this.run };
     }
   },
 };

--- a/client/src/components/core/ViewControls/template.html
+++ b/client/src/components/core/ViewControls/template.html
@@ -45,6 +45,7 @@
       :layout="imageGallery"
       :rows="numrows"
       :columns="numcols"
+      :currentStep="step"
       @close="showSaveDialog=false"
     />
     <load-dialog

--- a/client/src/components/core/ViewControls/template.html
+++ b/client/src/components/core/ViewControls/template.html
@@ -46,11 +46,13 @@
       :rows="numrows"
       :columns="numcols"
       :currentStep="step"
+      :meta="meta"
       @close="showSaveDialog=false"
     />
     <load-dialog
       :visible="showLoadDialog"
       :views="views"
+      :meta="meta"
       @close="showLoadDialog=false"
     />
   </v-row>

--- a/client/src/components/core/ViewControls/template.html
+++ b/client/src/components/core/ViewControls/template.html
@@ -61,4 +61,4 @@
       View Autosaved: {{ new Date(lastSaved).toLocaleTimeString() }}
     </span>
   </v-row>
-</v-row>
+</v-column>

--- a/client/src/components/core/ViewControls/template.html
+++ b/client/src/components/core/ViewControls/template.html
@@ -1,54 +1,61 @@
-<v-row>
-  <v-col :sm="4" v-bind:style="{alignItems: 'center'}">
-    <v-tooltip top>
-      <template v-slot:activator="{on, attrs}">
-        <v-button icon v-on:click="loadView()">
-          <v-icon
-            v-on="on"
-            v-bind="attrs"
-          >
-            mdi-view-grid-outline
-          </v-icon>
-        </v-button>
-      </template>
-      <span>Load View</span>
-    </v-tooltip>
-  </v-col>
-  <v-col :sm="4" v-bind:style="{alignItems: 'center'}">
-    <v-tooltip top>
-      <template v-slot:activator="{on, attrs}">
-        <v-button icon @click.stop="saveView()">
-          <v-icon v-on="on" v-bind="attrs">
-            mdi-view-grid-plus-outline
-          </v-icon>
-        </v-button>
-      </template>
-    <span>Save View</span>
-    </v-tooltip>
-  </v-col>
-  <v-col :sm="4" v-bind:style="{alignItems: 'center'}">
-    <v-tooltip top>
-      <template v-slot:activator="{on, attrs}">
-        <v-button icon v-on:click="girderRest.logout()">
-          <v-icon v-on="on" v-bind="attrs">
-            $vuetify.icons.logout
-          </v-icon>
-        </v-button>
-      </template>
-    <span>Logout</span>
-    </v-tooltip>
-  </v-col>
-  <save-dialog
-    :visible="showSaveDialog"
-    :viewNames="viewNames"
-    :layout="imageGallery"
-    :rows="numrows"
-    :columns="numcols"
-    @close="showSaveDialog=false"
-  />
-  <load-dialog
-    :visible="showLoadDialog"
-    :views="views"
-    @close="showLoadDialog=false"
-  />
+<v-column>
+  <v-row>
+    <v-col :sm="4" v-bind:style="{alignItems: 'center'}">
+      <v-tooltip top>
+        <template v-slot:activator="{on, attrs}">
+          <v-button icon v-on:click="loadView()">
+            <v-icon
+              v-on="on"
+              v-bind="attrs"
+            >
+              mdi-view-grid-outline
+            </v-icon>
+          </v-button>
+        </template>
+        <span>Load View</span>
+      </v-tooltip>
+    </v-col>
+    <v-col :sm="4" v-bind:style="{alignItems: 'center'}">
+      <v-tooltip top>
+        <template v-slot:activator="{on, attrs}">
+          <v-button icon @click.stop="saveView()">
+            <v-icon v-on="on" v-bind="attrs">
+              mdi-view-grid-plus-outline
+            </v-icon>
+          </v-button>
+        </template>
+      <span>Save View</span>
+      </v-tooltip>
+    </v-col>
+    <v-col :sm="4" v-bind:style="{alignItems: 'center'}">
+      <v-tooltip top>
+        <template v-slot:activator="{on, attrs}">
+          <v-button icon v-on:click="girderRest.logout()">
+            <v-icon v-on="on" v-bind="attrs">
+              $vuetify.icons.logout
+            </v-icon>
+          </v-button>
+        </template>
+      <span>Logout</span>
+      </v-tooltip>
+    </v-col>
+    <save-dialog
+      :visible="showSaveDialog"
+      :viewNames="viewNames"
+      :layout="imageGallery"
+      :rows="numrows"
+      :columns="numcols"
+      @close="showSaveDialog=false"
+    />
+    <load-dialog
+      :visible="showLoadDialog"
+      :views="views"
+      @close="showLoadDialog=false"
+    />
+  </v-row>
+  <v-row v-if="lastSaved">
+    <span v-bind:style="{fontSize: 'small', opacity: '0.5'}">
+      View Autosaved: {{ new Date(lastSaved).toLocaleTimeString() }}
+    </span>
+  </v-row>
 </v-row>

--- a/client/src/components/core/ViewControls/template.html
+++ b/client/src/components/core/ViewControls/template.html
@@ -41,7 +41,7 @@
     </v-col>
     <save-dialog
       :visible="showSaveDialog"
-      :viewNames="viewNames"
+      :viewInfo="viewInfo"
       :layout="imageGallery"
       :rows="numrows"
       :columns="numcols"

--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -257,4 +257,8 @@ export default {
       this.initialLoad = true;
     },
   },
+
+  mounted() {
+    this.$root.$children[0].$emit('gallery-mounted');
+  }
 };

--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -143,6 +143,7 @@ export default {
       event.preventDefault();
       var items = JSON.parse(event.dataTransfer.getData('application/x-girder-items'));
       this.itemId = items[0]._id;
+      this.$root.$children[0].$emit('item-added', this.itemId);
     },
 
     preCacheImages: function () {

--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -256,8 +256,4 @@ export default {
       this.initialLoad = true;
     },
   },
-
-  mounted () {
-    this.$root.$children[0].$emit("gallery-mounted");
-  },
 };

--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -259,6 +259,10 @@ export default {
   },
 
   mounted() {
-    this.$root.$children[0].$emit('gallery-mounted');
+    this.$root.$children[0].$emit('gallery-count-changed', 1);
+  },
+
+  destroyed() {
+    this.$root.$children[0].$emit('gallery-count-changed', -1);
   }
 };

--- a/client/src/components/widgets/LoadDialog/script.js
+++ b/client/src/components/widgets/LoadDialog/script.js
@@ -81,6 +81,40 @@ export default {
       this.$root.$children[0].$emit('view-selected', this.selection);
       this.clearSelection();
     },
+    async loadAsTemplate() {
+      // Create a list of selection's item ids
+      let templateView = {
+        rows: this.selection.rows,
+        columns: this.selection.columns,
+        items: {},
+        step: 1,
+        meta: {...this.meta},
+      }
+
+      async function asyncForEach(keys, values, callback) {
+        for (let index = 0; index < values.length; index++) {
+          const data = await callback(values[index]);
+          templateView.items[`${keys[index]}`] = data;
+        }
+      }
+
+      const keys = Object.keys(this.selection.items);
+      const values = Object.values(this.selection.items);
+      await asyncForEach(keys, values, async(value) => {
+        const response = await this.girderRest.get(`/item/${value}`);
+        const run = this.meta.run;
+        const name = response.data.name;
+        const endpoint = `/resource/${run}/search?type=folder&q=${name}`;
+        const result = await this.girderRest.get(endpoint);
+        if (result.data && result.data.results.length) {
+          return result.data.results[0].value._id;
+        }
+        return null;
+      });
+
+      this.$root.$children[0].$emit('view-selected', templateView);
+      this.clearSelection();
+    },
     rowSelected(selection) {
       this.clicks++;
       this.selection = selection;
@@ -129,6 +163,13 @@ export default {
           this.$parent.$emit('views-modified');
         })
         .catch((error) => { console.log('error: ', error) });
+    },
+    canBeTemplate() {
+      if (this.selection && this.meta) {
+        const { simulation, run } = this.selection.meta;
+        return simulation === this.meta.simulation && run !== this.meta.run;
+      }
+      return false;
     },
   },
 }

--- a/client/src/components/widgets/LoadDialog/script.js
+++ b/client/src/components/widgets/LoadDialog/script.js
@@ -45,13 +45,13 @@ export default {
     },
     filteredViews() {
       return this.views.filter((item) => {
-        const notDefault = this.viewIsNotDefault(item);
+        const notAutoSave = this.viewIsNotAutoSave(item);
         const isPublic = this.viewIsPublic(item);
         const createdByUser = this.viewCreatedByUser(item);
         if (parseInt(this.activeTab) === 0) {
-          return notDefault && (isPublic || createdByUser);
+          return notAutoSave && (isPublic || createdByUser);
         } else {
-          return notDefault && createdByUser;
+          return notAutoSave && createdByUser;
         }
       })
     },
@@ -109,11 +109,11 @@ export default {
       }
       return false;
     },
-    viewIsNotDefault(item) {
+    viewIsNotAutoSave(item) {
       const userId = this.girderRest.user._id;
       // Safe to assume the user did not create this view and it is an
-      // auto-saved default view for a run if it contains their userId
-      const nameIncludes = item.name.includes(`_${userId}_default`);
+      // auto-saved view for a run if it contains their userId
+      const nameIncludes = item.name.includes(`_${userId}`);
       return !nameIncludes;
     },
     async toggleViewStatus() {

--- a/client/src/components/widgets/LoadDialog/script.js
+++ b/client/src/components/widgets/LoadDialog/script.js
@@ -41,7 +41,12 @@ export default {
           this.$emit('close');
         }
       }
-    }
+    },
+    filteredViews() {
+      return this.views.filter((item) => {
+        return this.viewIsPublic(item) || this.viewCreatedByUser(item);
+      })
+    },
   },
 
   methods: {
@@ -89,6 +94,22 @@ export default {
     },
     viewCreatedByUser(item) {
       return this.girderRest.user._id === item.creatorId;
+    },
+    viewIsPublic(item) {
+      if (item) {
+        return item.public;
+      }
+      return false;
+    },
+    async toggleViewStatus() {
+      this.dialogTogglePublic = false;
+      var formData = new FormData();
+      formData.set('public', !this.selection.public);
+      await this.girderRest.put(`/view/${this.selection._id}`, formData)
+        .then(() => {
+          this.$parent.$emit('views-modified');
+        })
+        .catch((error) => { console.log('error: ', error) });
     },
   },
 }

--- a/client/src/components/widgets/LoadDialog/script.js
+++ b/client/src/components/widgets/LoadDialog/script.js
@@ -9,6 +9,7 @@ export default {
       disableLoad: true,
       search: '',
       selection: null,
+      dialogTogglePublic: false,
     };
   },
 

--- a/client/src/components/widgets/LoadDialog/script.js
+++ b/client/src/components/widgets/LoadDialog/script.js
@@ -21,6 +21,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    meta: {
+      type: Object,
+      default: () => {},
+    },
   },
 
   computed: {

--- a/client/src/components/widgets/LoadDialog/script.js
+++ b/client/src/components/widgets/LoadDialog/script.js
@@ -44,7 +44,11 @@ export default {
     },
     filteredViews() {
       return this.views.filter((item) => {
-        return this.viewIsPublic(item) || this.viewCreatedByUser(item);
+        return (
+          this.viewIsPublic(item) ||
+          this.viewCreatedByUser(item) ||
+          this.viewIsDefault(item)
+        );
       })
     },
   },
@@ -81,7 +85,7 @@ export default {
         this.load();
       }
     },
-    loadSelectedRow(event, selection) {
+    loadSelectedRow(_event, selection) {
       this.selection = selection.item;
       this.load();
     },
@@ -100,6 +104,19 @@ export default {
         return item.public;
       }
       return false;
+    },
+    async viewIsDefault(item) {
+      if ('default' in item.name) {
+        const [simulation, run] = item.name.split('_');
+        let { data } = await this.girderRest.get(`/folder/${simulation}`)
+        if (data) {
+          let { data } = await this.girderRest.get(`/folder/${run}`);
+          if (data) {
+            return true
+          }
+        }
+      }
+      return false
     },
     async toggleViewStatus() {
       this.dialogTogglePublic = false;

--- a/client/src/components/widgets/LoadDialog/template.html
+++ b/client/src/components/widgets/LoadDialog/template.html
@@ -23,7 +23,7 @@
                 hide-default-footer
                 height="300px"
                 :headers="headers"
-                :items="views"
+                :items="filteredViews"
                 :item-class="rowClass"
                 :search="search"
                 @click:row="rowSelected"
@@ -35,9 +35,45 @@
                   <span>{{new Date(item.created).toLocaleDateString()}}</span>
                 </template>
                 <template v-slot:item.actions="{item}">
-                  <v-icon v-show="viewCreatedByUser(item)" small @click='dialogDelete=true'>
-                    mdi-delete
-                  </v-icon>
+                  <v-tooltip left>
+                    <template v-slot:activator="{on}">
+                      <v-icon
+                        v-on="on"
+                        v-show="viewCreatedByUser(item)"
+                        small
+                        @click='dialogDelete=true'
+                      >
+                        mdi-delete
+                      </v-icon>
+                    </template>
+                    <span>Delete View</span>
+                  </v-tooltip>
+                  <v-tooltip right>
+                    <template v-slot:activator="{on}">
+                      <v-icon
+                        v-on="on"
+                        v-show="viewCreatedByUser(item) && viewIsPublic(item)"
+                        small
+                        @click='dialogTogglePublic=true'
+                      >
+                        mdi-earth
+                      </v-icon>
+                    </template>
+                    <span>Make View Private</span>
+                  </v-tooltip>
+                  <v-tooltip right>
+                    <template v-slot:activator="{on}">
+                      <v-icon
+                        v-on="on"
+                        v-show="viewCreatedByUser(item) && !viewIsPublic(item)"
+                        small
+                        @click='dialogTogglePublic=true'
+                      >
+                        mdi-lock
+                      </v-icon>
+                    </template>
+                    <span>Make View Public</span>
+                  </v-tooltip>
                 </template>
               </v-data-table>
             </v-col>
@@ -49,6 +85,22 @@
                 <v-spacer></v-spacer>
                 <v-btn text @click="dialogDelete=false">Cancel</v-btn>
                 <v-btn text @click="deleteView">OK</v-btn>
+                <v-spacer></v-spacer>
+              </v-card-actions>
+            </v-card>
+          </v-dialog>
+          <v-dialog v-model="dialogTogglePublic" max-width="550px">
+            <v-card>
+              <v-card-title v-if="viewIsPublic(selection)" class="text-h5">
+                Are you sure you would like to make this view private?
+              </v-card-title>
+              <v-card-title v-else class="text-h5">
+                Are you sure you would like to make this view public?
+              </v-card-title>
+              <v-card-actions>
+                <v-spacer></v-spacer>
+                <v-btn text @click="dialogTogglePublic=false">Cancel</v-btn>
+                <v-btn text @click="toggleViewStatus">OK</v-btn>
                 <v-spacer></v-spacer>
               </v-card-actions>
             </v-card>

--- a/client/src/components/widgets/LoadDialog/template.html
+++ b/client/src/components/widgets/LoadDialog/template.html
@@ -1,4 +1,8 @@
 <v-dialog v-model="loadDialog" max-width="700px">
+  <v-tabs v-model="activeTab">
+    <v-tab :key="0">All Views</v-tab>
+    <v-tab :key="1">My Views</v-tab>
+  </v-tabs>
   <v-card>
     <v-card-title>
       Load New View

--- a/client/src/components/widgets/LoadDialog/template.html
+++ b/client/src/components/widgets/LoadDialog/template.html
@@ -82,7 +82,7 @@
               </v-data-table>
             </v-col>
           </v-row>
-          <v-dialog v-model="dialogDelete" max-width="500px">
+          <v-dialog persistent v-model="dialogDelete" max-width="500px">
             <v-card>
               <v-card-title class="text-h5">Are you sure you want to delete this item?</v-card-title>
               <v-card-actions>
@@ -93,7 +93,7 @@
               </v-card-actions>
             </v-card>
           </v-dialog>
-          <v-dialog v-model="dialogTogglePublic" max-width="550px">
+          <v-dialog persistent v-model="dialogTogglePublic" max-width="550px">
             <v-card>
               <v-card-title v-if="viewIsPublic(selection)" class="text-h5">
                 Are you sure you would like to make this view private?

--- a/client/src/components/widgets/LoadDialog/template.html
+++ b/client/src/components/widgets/LoadDialog/template.html
@@ -117,6 +117,9 @@
       <v-btn text @click.stop="clearSelection()">
         Cancel
       </v-btn>
+      <v-btn :disabled="!canBeTemplate()" text @click.stop="loadAsTemplate()">
+        Load as Template
+      </v-btn>
       <v-btn text :disabled="selection===null" @click.stop="load()">
         Load
       </v-btn>

--- a/client/src/components/widgets/SaveDialog/script.js
+++ b/client/src/components/widgets/SaveDialog/script.js
@@ -36,10 +36,10 @@ export default {
       type: Boolean,
       default: false,
     },
-    viewNames: {
-      type: Array,
-      default: () => [],
-    }
+    meta: {
+      type: Object,
+      default: () => ({}),
+    },
   },
 
   computed: {
@@ -64,6 +64,7 @@ export default {
         this.newViewName,
         this.rows,
         this.columns,
+        this.meta,
         this.currentStep,
         isPublic);
       this.girderRest.post('/view', formData);

--- a/client/src/components/widgets/SaveDialog/script.js
+++ b/client/src/components/widgets/SaveDialog/script.js
@@ -1,3 +1,5 @@
+import { saveLayout } from "../../../utils/utilityFunctions";
+
 export default {
   inject: ['girderRest'],
 
@@ -9,6 +11,7 @@ export default {
         unique: value => !this.viewNames.includes(value) || 'View name already exists.',
       },
       invalidInput: true,
+      visibility: 'true',
     };
   },
 
@@ -50,20 +53,10 @@ export default {
   },
 
   methods: {
-    processLayout(formData) {
-      const items = {}
-      this.layout.forEach(item => {
-        const { row, col } = item.$attrs;
-        items[`${row}::${col}`] = item.itemId;
-      });
-      formData.set('items', JSON.stringify(items));
-    },
     save() {
-      var formData = new FormData();
-      this.processLayout(formData);
-      formData.set('name', this.newViewName);
-      formData.set('rows', this.rows);
-      formData.set('columns', this.columns);
+      const isPublic = (this.visibility === 'public');
+      const formData = saveLayout(
+        this.layout, this.newViewName, this.rows, this.columns, isPublic);
       this.girderRest.post('/view', formData);
       this.saveDialog = false;
     },

--- a/client/src/components/widgets/SaveDialog/script.js
+++ b/client/src/components/widgets/SaveDialog/script.js
@@ -20,6 +20,10 @@ export default {
       type: Number,
       default: 1,
     },
+    currentStep: {
+      type: Number,
+      default: 1,
+    },
     layout: {
       type: Array,
       default: () => [],
@@ -56,7 +60,12 @@ export default {
     save() {
       const isPublic = (this.visibility === 'public');
       const formData = saveLayout(
-        this.layout, this.newViewName, this.rows, this.columns, isPublic);
+        this.layout,
+        this.newViewName,
+        this.rows,
+        this.columns,
+        this.currentStep,
+        isPublic);
       this.girderRest.post('/view', formData);
       this.saveDialog = false;
     },

--- a/client/src/components/widgets/SaveDialog/template.html
+++ b/client/src/components/widgets/SaveDialog/template.html
@@ -12,6 +12,7 @@
                 v-model="newViewName"
                 label="Name"
                 :rules="[rules.required, rules.unique]"
+                @keydown.enter="checkForOverwrite"
               />
             </v-col>
           </v-row>
@@ -24,6 +25,17 @@
             </v-col>
           </v-row>
         </v-container>
+        <v-dialog persistent v-model="dialogOverwrite" max-width="450px">
+          <v-card>
+            <v-card-title class="text-h5">A view with this name already exists, are you sure you'd like to overwrite it?</v-card-title>
+            <v-card-actions>
+              <v-spacer></v-spacer>
+              <v-btn text @click="dialogOverwrite=false">Cancel</v-btn>
+              <v-btn text @click="save(false)">OK</v-btn>
+              <v-spacer></v-spacer>
+            </v-card-actions>
+          </v-card>
+        </v-dialog>
       </v-form>
     </v-card-text>
     <v-card-actions>
@@ -31,7 +43,7 @@
       <v-btn text @click.stop="saveDialog=false">
         Close
       </v-btn>
-      <v-btn text :disabled="invalidInput" @click.stop="save()">
+      <v-btn text @click.stop="checkForOverwrite">
         Save
       </v-btn>
     </v-card-actions>

--- a/client/src/components/widgets/SaveDialog/template.html
+++ b/client/src/components/widgets/SaveDialog/template.html
@@ -15,6 +15,14 @@
               />
             </v-col>
           </v-row>
+          <v-row>
+            <v-col cols="12" align-self="end">
+              <v-radio-group v-model="visibility" mandatory row>
+                <v-radio label="Public View" value="public"/>
+                <v-radio label="Private View" value="private"/>
+              </v-radio-group>
+            </v-col>
+          </v-row>
         </v-container>
       </v-form>
     </v-card-text>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -4,7 +4,7 @@ import {isNil} from 'lodash';
 
 Vue.use(Girder);
 
-let apiRoot = `${window.location}/api/v1`
+let apiRoot = `${window.location}api/v1`
 let authenticateWithCredentials = false;
 if (!isNil(process.env.VUE_APP_API_URL)) {
   apiRoot = process.env.VUE_APP_API_URL;

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -69,7 +69,7 @@
   display: flex;
   flex-flow: column;
   max-height: 20%;
-  min-height: 200px;
+  min-height: 220px;
   overflow: auto;
   padding: 5px;
   .row {

--- a/client/src/utils/utilityFunctions.js
+++ b/client/src/utils/utilityFunctions.js
@@ -1,0 +1,21 @@
+export function saveLayout(layout, name, rows, cols, meta, step=1, vis=true) {
+  var formData = new FormData();
+  processLayout(formData, layout);
+  formData.set('name', name);
+  formData.set('rows', rows);
+  formData.set('columns', cols);
+  formData.set('step', step);
+  formData.set('public', vis);
+  formData.set('meta', JSON.stringify(meta))
+
+  return formData;
+}
+
+function processLayout(formData, layout) {
+  const items = {}
+  layout.forEach(item => {
+    const { row, col } = item.$attrs;
+    items[`${row}::${col}`] = item.itemId;
+  });
+  formData.set('items', JSON.stringify(items));
+}

--- a/girder/esimmon_plugin/esimmon_plots/models/view.py
+++ b/girder/esimmon_plugin/esimmon_plots/models/view.py
@@ -42,13 +42,14 @@ class View(AccessControlledModel):
 
         return doc
 
-    def create_view(self, name, rows, columns, step, items, public, user):
+    def create_view(self, name, rows, columns, step, items, meta, public, user):
         view = {
             'name': name,
             'rows': rows,
             'columns': columns,
             'step': step,
             'items': items,
+            'meta': meta,
             'created': datetime.datetime.utcnow(),
             'creatorId': user['_id'],
             'creatorFirst': user['firstName'],

--- a/girder/esimmon_plugin/esimmon_plots/models/view.py
+++ b/girder/esimmon_plugin/esimmon_plots/models/view.py
@@ -59,21 +59,5 @@ class View(AccessControlledModel):
 
         return view
 
-    def search(self, text, user, limit, offset, sort):
-        if text is not None:
-            cursor = self.textSearch(text, sort=sort)
-        else:
-            cursor = self.find({}, sort=sort)
-
-        filtered_results = self.filterResultsByPermission(
-            cursor=cursor,
-            user=user,
-            level=AccessType.READ,
-            limit=limit,
-            offset=offset
-        )
-
-        return filtered_results
-
     def remove(self, view):
       super().remove(view)

--- a/girder/esimmon_plugin/esimmon_plots/models/view.py
+++ b/girder/esimmon_plugin/esimmon_plots/models/view.py
@@ -32,7 +32,7 @@ class View(AccessControlledModel):
             raise ValidationException('Items must not be empty.', 'items')
 
         # Ensure unique names
-        q = {'name': doc['name']}
+        q = {'name': doc['name'], 'creatorId': doc['creatorId']}
         if '_id' in doc:
             q['_id'] = {'$ne': doc['_id']}
         existing = self.findOne(q)

--- a/girder/esimmon_plugin/esimmon_plots/models/view.py
+++ b/girder/esimmon_plugin/esimmon_plots/models/view.py
@@ -42,11 +42,12 @@ class View(AccessControlledModel):
 
         return doc
 
-    def create_view(self, name, rows, columns, items, public, user):
+    def create_view(self, name, rows, columns, step, items, public, user):
         view = {
             'name': name,
             'rows': rows,
             'columns': columns,
+            'step': step,
             'items': items,
             'created': datetime.datetime.utcnow(),
             'creatorId': user['_id'],

--- a/girder/esimmon_plugin/esimmon_plots/view.py
+++ b/girder/esimmon_plugin/esimmon_plots/view.py
@@ -22,16 +22,24 @@ class View(Resource):
         Description('List or search for views.')
         .responseClass('View', array=True)
         .param('text', 'Pass this to perform a full text search for views', required=False)
+        .param('exact', 'If true, only return exact name matches. This is '
+               'case sensitive.', required=False, dataType='boolean', default=False)
         .pagingParams(defaultSort='name')
     )
-    def find(self, text=None, offset=0, limit=0, sort=None):
-        return list(self._model.search(
-            text=text,
-            user=self.getCurrentUser(),
-            offset=offset,
-            limit=limit,
-            sort=sort
-        ))
+    def find(self, text=None, exact=False, offset=0, limit=0, sort=None):
+        user = self.getCurrentUser()
+        if text is not None:
+          if exact:
+            viewList = self._model.find(
+              {'name': text}, offset=offset, limit=limit, sort=sort)
+          else:
+            viewList = self._model.textSearch(
+              text, user=user, offset=offset, limit=limit, sort=sort)
+        else:
+          viewList = self._model.list(
+            user=user, offset=offset, limit=limit, sort=sort)
+
+        return viewList
 
     @access.user
     @autoDescribeRoute(

--- a/girder/esimmon_plugin/esimmon_plots/view.py
+++ b/girder/esimmon_plugin/esimmon_plots/view.py
@@ -52,11 +52,13 @@ class View(Resource):
         .param('step', "Time step to start at.")
         .jsonParam('items', 'The object describing the items shown and their position in the grid.',
                     paramType='formData', requireObject=True)
+        .jsonParam('meta', 'An object describing meta data to associate with the view.',
+                    paramType='formData', requireObject=True, required=False)
         .param('public', 'Whether this view should be available to everyone.', 
                 required=False, dataType='boolean', default=True, paramType='formData')
         .errorResponse('A parameter was invalid, or the specified name already exists in the system.')
     )
-    def create_view(self, name, rows, columns, items, step=1, public=True):
+    def create_view(self, name, rows, columns, items, meta, step=1, public=True):
         user = self.getCurrentUser()
 
         view = self._model.create_view(
@@ -66,7 +68,8 @@ class View(Resource):
             step=step,
             items=items,
             public=public,
-            user=user
+            user=user,
+            meta=meta,
         )
 
         return view

--- a/girder/esimmon_plugin/esimmon_plots/view.py
+++ b/girder/esimmon_plugin/esimmon_plots/view.py
@@ -90,11 +90,12 @@ class View(Resource):
       .param('columns', 'The number of columns in the view.', required=False)
       .jsonParam('items', 'The object describing the items shown and their position in the grid.',
                  required=False)
+      .param('step', 'The step that the view should begin at.', required=False)
       .param('public', 'Whether this view should be available to everyone.',
              required=False, dataType='boolean')
       .errorResponse()
     )
-    def update_view(self, view, name=None, rows=None, columns=None, items=None, public=None):
+    def update_view(self, view, name=None, rows=None, columns=None, items=None, step=None, public=None):
       if name is not None:
         view['name'] = name
       if rows is not None:
@@ -103,6 +104,8 @@ class View(Resource):
         view['columns'] = columns
       if items is not None:
         view['items'] = items
+      if step is not None:
+        view['step'] = step
       if public is not None:
         self._model.setPublic(view, public, save=False)
 

--- a/girder/esimmon_plugin/esimmon_plots/view.py
+++ b/girder/esimmon_plugin/esimmon_plots/view.py
@@ -49,19 +49,21 @@ class View(Resource):
         .param('rows', "The number of rows in the view.", paramType='formData')
         .param('columns', "The number of columns in the view.",
                 paramType='formData')
+        .param('step', "Time step to start at.")
         .jsonParam('items', 'The object describing the items shown and their position in the grid.',
                     paramType='formData', requireObject=True)
         .param('public', 'Whether this view should be available to everyone.', 
                 required=False, dataType='boolean', default=True, paramType='formData')
         .errorResponse('A parameter was invalid, or the specified name already exists in the system.')
     )
-    def create_view(self, name, rows, columns, items, public=True):
+    def create_view(self, name, rows, columns, items, step=1, public=True):
         user = self.getCurrentUser()
 
         view = self._model.create_view(
             name=name,
             rows=rows,
             columns=columns,
+            step=step,
             items=items,
             public=public,
             user=user


### PR DESCRIPTION
This PR contains a lot of new features and behaviors:

- Auto-save a default View
  - Once a parameter is added the auto-save feature is enabled
  - The last added parameter is used to determine which simulation and run to associate the auto-saved (i.e. "default") View with
  - If a user navigates to a run with an associated default view they will shown a dialog that allows them to choose whether or not to load that default view
  - When a user navigates to a new run the auto-save will stop until a new parameter is added again. This is to prevent the default view from being associated with the wrong simulation/run.
  - Text has been added to the bottom of the view controls to indicate that the View is being auto-saved and when the last save happened
    ![autosave_text](https://user-images.githubusercontent.com/51238406/154543623-aa804222-c91c-4307-afa5-4c9e2c85d23c.png)
- Remember time step
  - When a View is save (automatically or manually) the current time step at the time of save is saved with the View
  - When a View is loaded it will automatically be loaded at the step associated with it
- Improved UI
  - Cleaned up sizing of some of the dialog boxes so that text is not wrapped mid-word
  - Add a tab to LoadView dialog to filter between user Views and all available Views
  - Add an icon to the LoadView dialog table that allows users to toggle the public/private status of their View(s)
- New View name requirements relaxed
  - Users can use any name that they would like for their View
  - If that user has an existing View with that name they are warned in the SaveView dialog and prompted to confirm that they wish to overwrite the existing View on save
- Load View as template
  - If a user opens the LoadView dialog within a run they will be able to load some Views as a template
  - Views qualify to be loaded as a template if they share the same simulation but *not* the same run as the current run.
  - If a template contains parameters not available within the current run the cell will simply be left empty
  - In the case of templates the time step associated with the View is ignored and is instead reset to step 1