### PR TITLE
Zoom updates

### DIFF
--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -1,5 +1,5 @@
 import Plotly from 'plotly.js-basic-dist-min';
-import { isNil } from 'lodash';
+import { isNil, isEqual } from 'lodash';
 import { mapGetters, mapActions, mapMutations } from 'vuex';
 import { decode } from '@msgpack/msgpack';
 
@@ -620,6 +620,10 @@ export default {
         picker.pick(point, this.renderer);
         if (picker.getActors().length !== 0 && this.startPoints) {
           const pickedPoints = picker.getPickedPositions();
+          if (isEqual(pickedPoints, this.startPoints)) {
+            // This was just a single click
+            return;
+          }
           const xMid = ((pickedPoints[0][0] - this.startPoints[0][0]) / 2) + this.startPoints[0][0];
           const yMid = ((pickedPoints[0][1] - this.startPoints[0][1]) / 2) + this.startPoints[0][1];
           const camera = this.renderer.getActiveCamera();

--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -106,6 +106,7 @@ export default {
       camera: null,
       focalPoint: null,
       scale: 0,
+      position: null,
     };
   },
 
@@ -578,6 +579,9 @@ export default {
       this.camera.setParallelProjection(true);
       if (!this.focalPoint && !this.scale) {
         this.renderer.resetCamera();
+        if (!this.position) {
+          this.position = this.camera.getPosition();
+        }
       }
     },
     removeRenderer() {
@@ -585,6 +589,7 @@ export default {
         this.renderWindow.removeRenderer(this.renderer);
         this.renderer = null;
         this.updateRendererCount(this.renderWindow.getRenderers().length);
+        this.position = null;
       }
     },
     enterCurrentRenderer() {
@@ -693,6 +698,7 @@ export default {
       }
       this.cornerAnnotation.setContainer(null);
       this.camera.setParallelProjection(true);
+      this.camera.setPosition(...this.position);
       this.renderer.resetCamera();
     },
     findClosestTime(value) {

--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -195,6 +195,14 @@ export default {
         this.react();
       }
     },
+    focalPoint(fp) {
+      if (!this.renderer || !fp) {
+        return;
+      }
+      this.camera.setFocalPoint(...fp);
+      this.camera.setParallelProjection(true);
+      this.camera.zoom(this.scale);
+    }
   },
 
   methods: {
@@ -628,8 +636,6 @@ export default {
           const yMid = ((pickedPoints[0][1] - this.startPoints[0][1]) / 2) + this.startPoints[0][1];
           const focalPoint = this.camera.getFocalPoint();
           this.setFocalPoint([xMid, yMid, focalPoint[2]]);
-          camera.setFocalPoint(xMid, yMid, focalPoint[2]);
-          camera.setParallelProjection(true);
         }
       });
       this.boxSelector.onBoxSelectChange((data) => {
@@ -660,7 +666,6 @@ export default {
           },
         });
         this.setScale(scale);
-        camera.zoom(scale);
       });
     },
     selectTimeStepFromPlot() {

--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -103,6 +103,7 @@ export default {
       inThisRenderer: false,
       startPoints: null,
       cornerAnnotation: null,
+      camera: null
     };
   },
 
@@ -484,12 +485,12 @@ export default {
       this.renderer.addActor(this.actor);
 
       // Update renderer window
-      const camera = this.renderer.getActiveCamera();
-      camera.setParallelProjection(true);
+      this.camera = this.renderer.getActiveCamera();
+      this.camera.setParallelProjection(true);
 
       // Create axis
       this.axes = vtkCubeAxesActor.newInstance();
-      this.axes.setCamera(camera);
+      this.axes.setCamera(this.camera);
       this.axes.setAxisLabels(data.xLabel, data.yLabel, '');
       this.axes.getGridActor().getProperty().setColor('black');
       this.axes.getGridActor().getProperty().setLineWidth(0.1);
@@ -558,14 +559,13 @@ export default {
       this.scalarBar.setScalarsToColors(lut);
 
       // Update camera
-      const camera = this.renderer.getActiveCamera();
       if (this.focalPoint) {
-        camera.setFocalPoint(...this.focalPoint);
+        this.camera.setFocalPoint(...this.focalPoint);
       }
       if (this.scale) {
-        camera.zoom(this.scale);
+        this.camera.zoom(this.scale);
       }
-      camera.setParallelProjection(true);
+      this.camera.setParallelProjection(true);
 
       this.renderer.resetCamera();
     },
@@ -626,8 +626,7 @@ export default {
           }
           const xMid = ((pickedPoints[0][0] - this.startPoints[0][0]) / 2) + this.startPoints[0][0];
           const yMid = ((pickedPoints[0][1] - this.startPoints[0][1]) / 2) + this.startPoints[0][1];
-          const camera = this.renderer.getActiveCamera();
-          const focalPoint = camera.getFocalPoint();
+          const focalPoint = this.camera.getFocalPoint();
           this.setFocalPoint([xMid, yMid, focalPoint[2]]);
           camera.setFocalPoint(xMid, yMid, focalPoint[2]);
           camera.setParallelProjection(true);
@@ -640,7 +639,6 @@ export default {
         const { selection, view } = data;
         const [x1, y1, ] = view.displayToNormalizedDisplay(selection[0], selection[2], selection[4]);
         const [x2, y2, ] = view.displayToNormalizedDisplay(selection[1], selection[3], selection[5]);
-        const camera = this.renderer.getActiveCamera();
         const bounds = this.renderer.computeVisiblePropBounds();
         const x = (bounds[1] - bounds[0]) / 2;
         const y = (bounds[3] - bounds[2]) / 2;


### PR DESCRIPTION
Addresses the following issues:
- Ignore single clicks. This was previously causing unexpected shifting of the focal point.
- Always set the zoom *after* setting the focal point so that the camera is aligned correctly.
- Remember the selected zoom until the user double-clicks to zoom out. Previously the camera was reset on each new time step with an available plot.
- Prevent the camera position from drifting over time as the user zooms in and out by remembering the original position and setting it again on zoom out.

Fixes #148 