### PR TITLE
Improve annotations

### DIFF
--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -40,34 +40,6 @@ function parseZoomValues(data, globalY) {
   return zoomLevel;
 }
 
-function addAnnotations(data, zoom, yRange) {
-  if (!zoom) {
-    return
-  }
-
-  const xRange = [data.x[0], data.x[data.x.length-1]];
-  if (!yRange)
-    yRange = [Math.min(...data.y), Math.max(...data.y)];
-  const rangeText = (
-    `<b>
-      X: [${xRange[0].toPrecision(4)}, ${xRange[1].toPrecision(4)}]
-      Y: [${yRange[0].toPrecision(4)}, ${yRange[1].toPrecision(4)}]
-    </b>`
-  )
-
-  const annotations = [{
-    xref: 'paper',
-    yref: 'paper',
-    x: 0,
-    xanchor: 'left',
-    y: 1,
-    yanchor: 'bottom',
-    text: rangeText,
-    showarrow: false
-  }]
-  return annotations;
-}
-
 export default {
   name: "plotly",
 
@@ -114,7 +86,8 @@ export default {
       selectedTime: -1,
       // Set of the current timesteps we are fetching data for, used to prevent
       // duplicate prefetching.
-      prefetchRequested: new Set()
+      prefetchRequested: new Set(),
+      rangeText: [],
     };
   },
 
@@ -508,7 +481,7 @@ export default {
               nextImage.layout.yaxis.autorange = false;
             }
           }
-          nextImage.layout['annotations'] = addAnnotations(nextImage.data[0], this.zoomLevels, range);
+          this.setAnnotations(nextImage.data[0], this.zoomLevels, range);
           Plotly.react(this.$refs.plotly, nextImage.data, nextImage.layout, {autosize: true});
           if (!this.eventHandlersSet)
             this.setEventHandlers();
@@ -566,6 +539,7 @@ export default {
           return false;
         } else {
           this.zoom = null;
+          this.rangeText = [];
           if (this.syncZoom) {
             this.setZoomDetails({zoom: null, xAxis: null});
           }
@@ -845,6 +819,21 @@ export default {
           this.camera.setParallelScale(this.scale);
         }
       }
+    },
+    setAnnotations(data, zoom, yRange) {
+      if (!zoom) {
+        return
+      }
+
+      const xRange = [data.x[0], data.x[data.x.length-1]];
+      if (!yRange)
+        yRange = [Math.min(...data.y), Math.max(...data.y)];
+      this.rangeText = [
+        xRange[0].toPrecision(4),
+        xRange[1].toPrecision(4),
+        yRange[0].toPrecision(4),
+        yRange[1].toPrecision(4)
+      ]
     }
   },
 

--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -219,9 +219,7 @@ export default {
     }),
     relayoutPlotly() {
       const node =  this.$refs.plotly;
-      if (node !== undefined &&
-          node.childElementCount !== 0 &&
-          node.firstChild.tagName != 'I') {
+      if (node !== undefined && node.getElementsByClassName('plot-container') > 0) {
         Plotly.relayout(this.$refs.plotly, {
           'xaxis.autorange': true,
           'yaxis.autorange': true

--- a/client/src/components/widgets/ImageGallery/template.html
+++ b/client/src/components/widgets/ImageGallery/template.html
@@ -5,6 +5,9 @@
     @contextmenu.prevent="fetchMovie"
   >
     <div ref="plotly" class="plot">
+      <span v-if="rangeText.length" class="plotlyAnnotations">
+        xRange: [{{rangeText[0]}}, {{rangeText[1]}}] yRange: [{{rangeText[2]}}, {{rangeText[3]}}]
+      </span>
       <v-icon v-if="!itemId" large> input </v-icon>
     </div>
   </v-card>

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -193,3 +193,13 @@
   color: darkslategrey !important;
   padding: 0 3px !important;
 }
+
+.plotlyAnnotations {
+  position: absolute;
+  left: 0;
+  top: 25px;
+  z-index: 1;
+  background-color: white;
+  font-size: smaller;
+  padding-left: 5px;
+}

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -191,7 +191,9 @@
 .CornerAnnotation-module_northWest__23pUR {
   flex: auto !important;
   color: darkslategrey !important;
-  padding: 0 3px !important;
+  padding: 0 0 0 5px !important;
+  font-size: smaller;
+  background-color: white;
 }
 
 .plotlyAnnotations {


### PR DESCRIPTION
Gives the VTK.js annotations a white background to make them pop.
There is apparently a known issue with keeping Plotly annotations aligned nicely. To get around this I am now using a new `span` element and simply position the text that way. Also has a white background now to make the text legible in the case where the annotation is forced to overlap other text (although this case should be less frequent now).