### PR TITLE
Fix the load view option

### DIFF
--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -285,6 +285,7 @@ export default {
         }
       });
       this.setGridSize(0);
+      this.setCurrentTimeStep(this.viewTimeStep);
     },
 
     resetView() {
@@ -359,6 +360,7 @@ export default {
       loadedFromView: 'PLOT_LOADED_FROM_VIEW',
       initialDataLoaded: 'PLOT_INITIAL_LOAD',
       minTimeStep: 'PLOT_MIN_TIME_STEP',
+      viewTimeStep: 'PLOT_VIEW_TIME_STEP',
     }),
 
     location: {

--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -219,7 +219,8 @@ export default {
     }),
     relayoutPlotly() {
       const node =  this.$refs.plotly;
-      if (node !== undefined && node.getElementsByClassName('plot-container') > 0) {
+      const elems = node?.getElementsByClassName('plot-container');
+      if (node !== undefined && elems.length > 0) {
         Plotly.relayout(this.$refs.plotly, {
           'xaxis.autorange': true,
           'yaxis.autorange': true
@@ -266,7 +267,6 @@ export default {
             reader.onload = () => {
               if (plotType === 'vtk') {
                 const img = decode(reader.result);
-                Plotly.purge(this.$refs.plotly);
                 this.addRenderer(img);
                 this.loadedTimestepData.push({
                   timestep: timeStep,
@@ -329,14 +329,12 @@ export default {
       var items = JSON.parse(event.dataTransfer.getData('application/x-girder-items'));
       this.itemId = items[0]._id;
       this.setLoadedFromView(false);
-      this.removeRenderer();
       this.$root.$children[0].$emit('item-added', this.itemId);
     },
     loadTemplateGallery: function (item) {
       this.itemId = item.id;
       this.zoom = item.zoom;
       this.setLoadedFromView(true);
-      this.removeRenderer();
     },
 
     /**
@@ -461,6 +459,7 @@ export default {
 
       if (!isNil(nextImage)) {
         if (nextImage.type === 'plotly') {
+          this.removeRenderer();
           if (!this.xaxis) {
             this.xaxis = nextImage.layout.xaxis.title.text;
           }
@@ -485,6 +484,7 @@ export default {
             this.setEventHandlers();
           this.json = true;
         } else {
+          this.removePlotly();
           if (!this.xaxis) {
             this.xaxis = nextImage.data.xLabel;
           }
@@ -682,11 +682,21 @@ export default {
       }
     },
     removeRenderer() {
+      // Remove the renderer if it exists, we're about to load a Plotly plot
       if (this.renderer) {
         this.renderWindow.removeRenderer(this.renderer);
         this.renderer = null;
         this.updateRendererCount(this.renderWindow.getRenderers().length);
         this.position = null;
+      }
+    },
+    removePlotly() {
+      // Remove the Plotly plot if it exists, we're about to load a VTK plot
+      const node =  this.$refs.plotly;
+      const elems = node?.getElementsByClassName('plot-container');
+      if (node !== undefined && elems.length > 0) {
+        Plotly.purge(this.$refs.plotly);
+        this.rangeText = [];
       }
     },
     enterCurrentRenderer() {
@@ -844,9 +854,5 @@ export default {
 
   destroyed() {
     this.updateCellCount(-1);
-    if (this.renderer) {
-      this.renderWindow.removeRenderer(this.renderer);
-      this.updateRendererCount(this.renderWindow.getRenderers().length);
-    }
   }
 };

--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -325,6 +325,7 @@ export default {
     },
     loadGallery: function (event) {
       event.preventDefault();
+      this.removeRenderer();
       this.zoom = null
       var items = JSON.parse(event.dataTransfer.getData('application/x-girder-items'));
       this.itemId = items[0]._id;
@@ -332,6 +333,7 @@ export default {
       this.$root.$children[0].$emit('item-added', this.itemId);
     },
     loadTemplateGallery: function (item) {
+      this.removeRenderer();
       this.itemId = item.id;
       this.zoom = item.zoom;
       this.setLoadedFromView(true);

--- a/client/src/components/widgets/ImageGallery/script.js
+++ b/client/src/components/widgets/ImageGallery/script.js
@@ -849,6 +849,11 @@ export default {
     this.updateCellCount(1);
     this.$el.addEventListener('mouseenter', this.enterCurrentRenderer);
     this.$el.addEventListener('mouseleave', this.exitCurrentRenderer);
+    this.$el.addEventListener('dblclick', () => {
+      if (this.renderer) {
+        this.resetZoom();
+      }
+    });
     window.addEventListener('resize', this.resize);
   },
 

--- a/client/src/store/plots.js
+++ b/client/src/store/plots.js
@@ -14,6 +14,7 @@ export default {
     boxSelector: null,
     focalPoint: null,
     scale: 0,
+    viewTimeStep: 1,
   },
   getters: {
     PLOT_ZOOM(state) {
@@ -58,6 +59,9 @@ export default {
     PLOT_SCALE(state) {
       return state.scale;
     },
+    PLOT_VIEW_TIME_STEP(state) {
+      return state.viewTimeStep;
+    },
   },
   mutations: {
     PLOT_ZOOM_SET(state, val) {
@@ -101,6 +105,9 @@ export default {
     },
     PLOT_SCALE_SET(state, val) {
       state.scale = val;
+    },
+    PLOT_VIEW_TIME_STEP_SET(state, val) {
+      state.viewTimeStep = val;
     },
   },
   actions: {

--- a/client/src/store/views.js
+++ b/client/src/store/views.js
@@ -232,7 +232,7 @@ export default {
       commit('VIEW_LAST_LOADED_ID_SET', view._id);
       // commit('VIEW_ZOOM_LEVELS', view.zoomLevels);
 
-      commit('PLOT_TIME_STEP_SET', parseInt(view.step));
+      commit('PLOT_VIEW_TIME_STEP_SET', parseInt(view.step));
       commit('UI_PAUSE_GALLERY_SET', true);
     },
     VIEW_UPDATE_EXISTING({state, dispatch}, name) {


### PR DESCRIPTION
Do not update the time step until all new images have been added. When loading a new image remove the renderer for Plotly plots if it exists or purge the Plotly plot for VTK plots if it exists.