### PR TITLE
Force slider to be reactive to min/max changes

### DIFF
--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -496,9 +496,5 @@ export default {
         this.setPaused(false);
       }
     },
-
-    currentTimeStep(step) {
-      console.log(this.minTimeStep, this.maxTimeStep, this.step)
-    },
   },
 };

--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -392,6 +392,14 @@ export default {
       }
       return loggedOut;
     },
+
+    sliderValue() {
+      if (this.minTimeStep <= this.currentTimeStep <= this.maxTimeStep) {
+        return this.currentTimeStep;
+      } else {
+        return this.minTimeStep;
+      }
+    }
   },
 
   watch: {
@@ -487,6 +495,10 @@ export default {
         // Default to playing once a parameter has been selected
         this.setPaused(false);
       }
+    },
+
+    currentTimeStep(step) {
+      console.log(this.minTimeStep, this.maxTimeStep, this.step)
     },
   },
 };

--- a/client/src/components/core/App/template.html
+++ b/client/src/components/core/App/template.html
@@ -63,7 +63,7 @@
                           :max="maxTimeStep"
                           :disabled="!dataLoaded"
                           height="1px"
-                          :value="currentTimeStep"
+                          :value="sliderValue"
                           @change="updateTimeStep"/>
               </v-col>
               <v-col :sm="1" class="text-xs-center">


### PR DESCRIPTION
Previously the slider would not update properly occasionally because it is only reactive to the value (the current time step) but that is updated before the min and max are sometimes. The value is now "computed" when the min/max are changed and so the slider is updated properly