### PR TITLE
Remove "log" key if no scaling is applied

### DIFF
--- a/fastapi/app/api/api_v1/endpoints/images.py
+++ b/fastapi/app/api/api_v1/endpoints/images.py
@@ -54,7 +54,8 @@ def create_plotly_image(plot_data: dict, format: str, zoom: dict):
     plot_data["layout"].pop("name", None)
     plot_data["layout"].pop("frames", None)
     if zoom:
-        if "log" in zoom:
+        log_scaling = zoom.get("log", False)
+        if log_scaling:
             plot_data["layout"]["xaxis"]["type"] = "log"
             plot_data["layout"]["yaxis"]["type"] = "log"
         if "range" in zoom:


### PR DESCRIPTION
Apply log scaling to saved images if the key exists and is set to true.