### PR TITLE
Extend movie/image download options

### DIFF
--- a/client/src/components/widgets/ContextMenu/script.js
+++ b/client/src/components/widgets/ContextMenu/script.js
@@ -64,7 +64,7 @@ export default {
       const endpoint = `variables/${id}/timesteps/${step}/image?format=${format}`;
       this.downloadData(endpoint, format, "image");
     },
-    fetchImages(format, timeSteps) {
+    fetchImages(format, timeSteps = null) {
       const { id } = this.itemInfo;
       let endpoint = `variables/${id}/timesteps/image?format=${format}`;
       if (timeSteps) {

--- a/client/src/components/widgets/ContextMenu/script.js
+++ b/client/src/components/widgets/ContextMenu/script.js
@@ -1,4 +1,5 @@
 import RangeDialog from "../RangeDialog";
+import DownloadOptions from "../DownloadOptions";
 import { v4 as uuidv4 } from "uuid";
 import { mapGetters, mapMutations } from "vuex";
 
@@ -13,6 +14,7 @@ export default {
 
   components: {
     RangeDialog,
+    DownloadOptions,
   },
 
   data() {
@@ -55,15 +57,27 @@ export default {
     ...mapMutations({
       showContextMenu: "UI_SHOW_CONTEXT_MENU_SET",
       updateItemInfo: "UI_CONTEXT_MENU_ITEM_DATA_SET",
+      showDownloadOptions: "UI_SHOW_DOWNLOAD_OPTIONS_SET",
     }),
     fetchImage(format) {
       const { id, step } = this.itemInfo;
       const endpoint = `variables/${id}/timesteps/${step}/image?format=${format}`;
       this.downloadData(endpoint, format, "image");
     },
-    fetchMovie(format) {
+    fetchImages(format, timeSteps) {
       const { id } = this.itemInfo;
-      const endpoint = `variables/${id}/timesteps/movie?format=${format}`;
+      let endpoint = `variables/${id}/timesteps/image?format=${format}`;
+      if (timeSteps) {
+        endpoint = `${endpoint}&selectedTimeSteps=${JSON.stringify(timeSteps)}`;
+      }
+      this.downloadData(endpoint, "zip", "image");
+    },
+    fetchMovie(format, timeSteps = null) {
+      const { id } = this.itemInfo;
+      let endpoint = `variables/${id}/timesteps/movie?format=${format}`;
+      if (timeSteps) {
+        endpoint = `${endpoint}&selectedTimeSteps=${JSON.stringify(timeSteps)}`;
+      }
       this.downloadData(endpoint, format, "movie");
     },
     downloadData(endpoint, format, type) {
@@ -112,6 +126,9 @@ export default {
     },
     dismiss(idx) {
       this.downloads.splice(idx, 1);
+    },
+    downloadOptions() {
+      this.showDownloadOptions(true);
     },
   },
 };

--- a/client/src/components/widgets/ContextMenu/template.html
+++ b/client/src/components/widgets/ContextMenu/template.html
@@ -15,25 +15,25 @@
       <v-divider v-if="itemInfo && !itemInfo.isVTK" />
       <v-list>
         <v-list-item dense @click="fetchImage('png')">
-          <v-list-item-title> Save Image as PNG </v-list-item-title>
+          <v-list-item-title> Save PNG Image </v-list-item-title>
         </v-list-item>
         <v-list-item dense @click="fetchImage('pdf')">
-          <v-list-item-title> Save Image as PDF </v-list-item-title>
+          <v-list-item-title> Save PDF Image </v-list-item-title>
         </v-list-item>
       </v-list>
       <v-divider />
       <v-list>
         <v-list-item dense @click="fetchMovie('mp4')">
-          <v-list-item-title> Download Movie as MP4 </v-list-item-title>
+          <v-list-item-title> Save MP4 Movie </v-list-item-title>
         </v-list-item>
         <v-list-item dense @click="fetchMovie('mpg')">
-          <v-list-item-title> Download Movie as MPG </v-list-item-title>
+          <v-list-item-title> Save MPG Movie </v-list-item-title>
         </v-list-item>
       </v-list>
       <v-divider />
       <v-list>
         <v-list-item dense @click="downloadOptions()">
-          <v-list-item-title> Download Options </v-list-item-title>
+          <v-list-item-title> Save As... </v-list-item-title>
         </v-list-item>
       </v-list>
     </v-card>

--- a/client/src/components/widgets/ContextMenu/template.html
+++ b/client/src/components/widgets/ContextMenu/template.html
@@ -30,6 +30,12 @@
           <v-list-item-title> Download Movie as MPG </v-list-item-title>
         </v-list-item>
       </v-list>
+      <v-divider />
+      <v-list>
+        <v-list-item dense @click="downloadOptions()">
+          <v-list-item-title> Download Options </v-list-item-title>
+        </v-list-item>
+      </v-list>
     </v-card>
   </v-menu>
   <range-dialog
@@ -37,6 +43,12 @@
     :param="parameter"
     :id="itemInfo ? itemInfo.id : ''"
     @close="showRangeDialog=false"
+  />
+  <download-options
+    :param="parameter"
+    :id="itemInfo ? itemInfo.id : ''"
+    :fetchImages="fetchImages"
+    :fetchMovie="fetchMovie"
   />
   <v-snackbar v-model="downloading" timeout="-1" absolute bottom right>
     <v-navigation-drawer stateless value="true">

--- a/client/src/components/widgets/DownloadOptions/index.vue
+++ b/client/src/components/widgets/DownloadOptions/index.vue
@@ -1,0 +1,3 @@
+<script src="./script.js" />
+<style src="../../../scss/gallery.scss" lang="scss" />
+<template src="./template.html" />

--- a/client/src/components/widgets/DownloadOptions/script.js
+++ b/client/src/components/widgets/DownloadOptions/script.js
@@ -117,9 +117,7 @@ export default {
     },
     computeListOfTimeSteps() {
       if (this.rangeSelection === "selectAll") {
-        return [...Array(this.maxStep - this.minStep + 1).keys()].map(
-          (x) => x + this.minStep
-        );
+        return;
       }
       let timeSteps = [];
       let selections = this.rangeInput.split(",");

--- a/client/src/components/widgets/DownloadOptions/script.js
+++ b/client/src/components/widgets/DownloadOptions/script.js
@@ -1,0 +1,169 @@
+import { mapActions, mapGetters, mapMutations } from "vuex";
+
+export default {
+  inject: ["girderRest"],
+
+  data() {
+    return {
+      activeTab: 0,
+      rangeInput: "",
+      rangeSelection: "selectAll",
+      formatSelection: "0",
+      hint: "",
+    };
+  },
+  props: {
+    allPlots: {
+      type: Object,
+      default: () => {},
+    },
+    id: {
+      type: String,
+      default: "",
+    },
+    param: {
+      type: String,
+      default: "",
+    },
+    fetchImages: {
+      type: Function,
+      default: () => {},
+    },
+    fetchMovie: {
+      type: Function,
+      default: () => {},
+    },
+  },
+  computed: {
+    ...mapGetters({
+      availableTimeSteps: "PLOT_AVAILABLE_TIME_STEPS",
+      visible: "UI_SHOW_DOWNLOAD_OPTIONS",
+      mathJaxOptions: "UI_MATH_JAX_OPTIONS",
+    }),
+    downloadsDialog: {
+      get() {
+        return this.visible;
+      },
+      set(value) {
+        this.showDownloadOptions(value);
+        if (value) {
+          this.updateHint();
+        }
+      },
+    },
+    disableInput() {
+      return this.rangeSelection === "selectAll";
+    },
+    minStep() {
+      if (this.id) {
+        return Math.min(...this.availableTimeSteps[`${this.id}`]) || 0;
+      }
+      return 0;
+    },
+    maxStep() {
+      if (this.id) {
+        return Math.max(...this.availableTimeSteps[`${this.id}`]) || 0;
+      }
+      return 0;
+    },
+    choice() {
+      return this.activeTab === 0 ? "Movie" : "Image";
+    },
+    formatOptions() {
+      const movieOptions = ["mp4", "mpg"];
+      const imageOptions = ["png", "pdf"];
+      return this.choice === "Movie" ? movieOptions : imageOptions;
+    },
+    format() {
+      return this.formatOptions[this.formatSelection];
+    },
+    invalidInput() {
+      if (this.rangeSelection == "selectAll") {
+        return false;
+      }
+      const regex = /^[0-9](?:-[0-9])?(?:,\s?[0-9](?:-[0-9])?)*$/g;
+      let validFormat = this.rangeInput.match(regex) === null;
+      if (validFormat) {
+        let selectedTimeSteps = this.rangeInput.split(/[-,]+/);
+        // Make sure values are acceptable
+        let containsInvalidTimeSteps = selectedTimeSteps.some((timeStep) => {
+          return timeStep < this.minStep || timeStep > this.maxStep;
+        });
+        return containsInvalidTimeSteps;
+      }
+      return true;
+    },
+  },
+  methods: {
+    ...mapActions({
+      updatePlotDetails: "PLOT_DETAILS_UPDATED",
+    }),
+    ...mapMutations({
+      showDownloadOptions: "UI_SHOW_DOWNLOAD_OPTIONS_SET",
+    }),
+    beginDownload() {
+      const valid = this.validate();
+      if (!valid) {
+        this.updateHint();
+        return;
+      }
+      const timeSteps = this.computeListOfTimeSteps();
+      if (this.activeTab === 0) {
+        this.fetchMovie(this.format, timeSteps);
+      } else {
+        this.fetchImages(this.format, timeSteps);
+      }
+      this.downloadsDialog = false;
+    },
+    computeListOfTimeSteps() {
+      if (this.rangeSelection === "selectAll") {
+        return [...Array(this.maxStep - this.minStep + 1).keys()].map(
+          (x) => x + this.minStep
+        );
+      }
+      let timeSteps = [];
+      let selections = this.rangeInput.split(",");
+      selections.forEach((selection) => {
+        let vals = selection.split("-");
+        if (vals.length > 1) {
+          const start = parseInt(vals[0]);
+          const end = parseInt(vals[1]);
+          const range = [...Array(end - start + 1).keys()].map(
+            (x) => x + start
+          );
+          timeSteps.push(...range);
+        } else {
+          timeSteps.push(parseInt(selection));
+        }
+      });
+      return timeSteps;
+    },
+    validate() {
+      return !this.invalidInput;
+    },
+    updateHint() {
+      if (this.invalidInput) {
+        this.hint = `Input must be ranges(start-stop) or values seperated by
+                    commas. Values must be within available range of time steps
+                    (${this.minStep}-${this.maxStep})`;
+      } else {
+        this.hint = `Available Range: ${this.minStep} - ${this.maxStep}`;
+      }
+    },
+  },
+  watch: {
+    rangeInput() {
+      if (this.hint.startsWith("Input")) {
+        // We're in error mode but the user has changed their input.
+        // Clear the error message if the input is now valid
+        this.updateHint();
+      }
+    },
+    minStep() {
+      this.updateHint();
+    },
+    maxStep() {
+      this.updateHint();
+    },
+  },
+};

--- a/client/src/components/widgets/DownloadOptions/template.html
+++ b/client/src/components/widgets/DownloadOptions/template.html
@@ -1,0 +1,57 @@
+<v-dialog v-model="downloadsDialog" max-width="700px">
+  <v-tabs v-model="activeTab">
+    <v-tab :key="0">Movies</v-tab>
+    <v-tab :key="1">Images</v-tab>
+  </v-tabs>
+  <v-card>
+    <v-card-title style="justify-content: center">
+      <span class="text-h6">
+        {{ choice }} Generation for
+        <vue-mathjax :formula="param" :options="mathJaxOptions" />
+      </span>
+    </v-card-title>
+    <v-card-text>
+      <v-form>
+        <v-container>
+          <v-row>
+            <v-col cols="6">
+              <v-radio-group v-model="rangeSelection" row dense>
+                <template v-slot:label>
+                  <div>Time Step Selection</div>
+                </template>
+                <v-radio label="All" value="selectAll" />
+                <v-radio label="Range" value="selectSubset" />
+              </v-radio-group>
+            </v-col>
+            <v-col cols="6">
+              <v-radio-group v-model="formatSelection" row dense>
+                <template v-slot:label>
+                  <div>Set Selection</div>
+                </template>
+                <v-radio :label="formatOptions[0]" value="0" />
+                <v-radio :label="formatOptions[1]" value="1" />
+              </v-radio-group>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col cols="12">
+              <v-text-field
+                v-model="rangeInput"
+                label="Range (e.g. 1-10, 15, 20-25)"
+                :hint="hint"
+                persistent-hint
+                :disabled="disableInput"
+                dense
+              />
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-form>
+    </v-card-text>
+    <v-card-actions>
+      <v-spacer />
+      <v-btn text @click.stop="downloadsDialog=false"> Cancel </v-btn>
+      <v-btn text @click.stop="beginDownload()"> Download </v-btn>
+    </v-card-actions>
+  </v-card>
+</v-dialog>

--- a/client/src/store/ui.js
+++ b/client/src/store/ui.js
@@ -21,6 +21,7 @@ export default {
         processEnvironments: true,
       },
     },
+    showDownloadOptions: false,
   },
   getters: {
     UI_AUTO_SAVE_DIALOG(state) {
@@ -59,6 +60,9 @@ export default {
     UI_MATH_JAX_OPTIONS(state) {
       return state.mathJaxOptions;
     },
+    UI_SHOW_DOWNLOAD_OPTIONS(state) {
+      return state.showDownloadOptions;
+    },
   },
   mutations: {
     UI_AUTO_SAVE_DIALOG_SET(state, val) {
@@ -93,6 +97,9 @@ export default {
     },
     UI_CONTEXT_MENU_ITEM_DATA_SET(state, val) {
       state.contextMenuItemData = val;
+    },
+    UI_SHOW_DOWNLOAD_OPTIONS_SET(state, val) {
+      state.showDownloadOptions = val;
     },
   },
   actions: {

--- a/fastapi/app/api/api_v1/endpoints/images.py
+++ b/fastapi/app/api/api_v1/endpoints/images.py
@@ -314,7 +314,11 @@ async def get_timestep_images(
     gc = get_girder_client(girder_token)
     item = gc.getItem(variable_id)
     timesteps = item["meta"]["timesteps"]
-    selectedTimeSteps = json.loads(unquote(selectedTimeSteps))
+    # Check if there are specific time steps to use
+    if selectedTimeSteps:
+        selectedTimeSteps = json.loads(unquote(selectedTimeSteps))
+    else:
+        selectedTimeSteps = timesteps
     # Check if there are additional settings to apply
     details = json.loads(unquote(details)) if details else {}
 


### PR DESCRIPTION
- Add `Download Options` to context menu
- Add dialog with additional options for downloads:
  - Download a zipped folder with a single time step, a range and/or list of time steps, or all available time steps as `png`s or `pdf`s
  - Download a movie with all or a range and/or list of time steps as `mp4` or `mpg`

![context_menu](https://user-images.githubusercontent.com/51238406/174169937-782c5f44-eb55-4374-8468-311381e8bd38.png)
![download_options](https://user-images.githubusercontent.com/51238406/174169942-1c5636cb-70ee-4898-836d-15a4fb533fa2.png)
