### PR TITLE
Add support for additional Plotly plot types

### DIFF
--- a/client/src/components/widgets/DownloadOptions/script.js
+++ b/client/src/components/widgets/DownloadOptions/script.js
@@ -15,6 +15,7 @@ export default {
   props: {
     allPlots: {
       type: Object,
+      // eslint-disable-next-line
       default: () => {},
     },
     id: {
@@ -27,10 +28,12 @@ export default {
     },
     fetchImages: {
       type: Function,
+      // eslint-disable-next-line
       default: () => {},
     },
     fetchMovie: {
       type: Function,
+      // eslint-disable-next-line
       default: () => {},
     },
   },

--- a/fastapi/app/api/api_v1/endpoints/images.py
+++ b/fastapi/app/api/api_v1/endpoints/images.py
@@ -48,12 +48,18 @@ router = APIRouter()
 
 def create_plotly_image(plot_data: dict, format: str, details: dict):
     # The json contains Javascript syntax. Update values for Python
-    for data in plot_data["data"]:
-        data["mode"] = "lines"
+    plot_type = plot_data["type"]
+    if plot_type != "bar":
+        mode = "lines" if plot_type == "lines" else "markers"
+        for data in plot_data["data"]:
+            data["mode"] = mode
+
     plot_data["layout"]["autosize"] = True
     plot_data["layout"]["xaxis"]["automargin"] = True
     plot_data["layout"]["yaxis"]["automargin"] = True
     plot_data["layout"]["title"]["x"] = 0.5
+    # TODO: Find the best solution for legengs that take up too much space
+    # plot_data["layout"]["showlegend"] = False
     plot_data["layout"].pop("name", None)
     plot_data["layout"].pop("frames", None)
     if details:
@@ -324,7 +330,7 @@ def create_mesh_image(plot_data: dict, format: str, details: dict):
 
 
 async def get_timestep_image_data(plot: dict, format: str, details: dict):
-    if plot["type"] == PlotFormat.plotly:
+    if plot["type"] in PlotFormat.plotly:
         image = create_plotly_image(plot, format, details)
     elif plot["type"] == PlotFormat.mesh or plot["type"] == PlotFormat.colormap:
         image = create_mesh_image(plot, format, details)

--- a/fastapi/app/api/api_v1/endpoints/variables.py
+++ b/fastapi/app/api/api_v1/endpoints/variables.py
@@ -58,6 +58,13 @@ def get_timestep_item(gc, group_folder_id, timestep):
 def get_timestep_bp_file_id(gc, group_folder_id, group_name, timestep):
     timestep_item = get_timestep_item(gc, group_folder_id, timestep)
 
+    # FIXME: This is a temporary hack to allow us to test the performance plots
+    # This block should be removed once those bp filenames are fixed.
+    if group_name == "HeatLoad" or group_name == "Poincare":
+        filename = f"{group_name}-{timestep_item['name'].lstrip('0')}.bp.tgz"
+    else:
+        filename = f"{group_name}.bp.tgz"
+
     for bp_file in gc.listFile(timestep_item["_id"]):
         if bp_file["name"] == filename:
             return bp_file["_id"]

--- a/fastapi/app/api/api_v1/endpoints/variables.py
+++ b/fastapi/app/api/api_v1/endpoints/variables.py
@@ -89,8 +89,7 @@ async def generate_plot_response(bp, variable: str):
     plot_config = json.loads(plot_config[0])
 
     plot_type = plot_config["type"]
-
-    if plot_type == PlotFormat.plotly:
+    if plot_type in PlotFormat.plotly:
         return await generate_plotly_response(plot_config, bp, variable)
     elif plot_type == PlotFormat.mesh:
         return await generate_mesh_response(plot_config, bp, variable)
@@ -106,7 +105,7 @@ async def generate_plot_data(bp, variable: str):
 
     plot_type = plot_config["type"]
 
-    if plot_type == PlotFormat.plotly:
+    if plot_type in PlotFormat.plotly:
         return await generate_plotly_data(plot_config, bp, variable)
     elif plot_type == PlotFormat.mesh:
         return await generate_mesh_data(plot_config, bp, variable)

--- a/fastapi/app/api/api_v1/endpoints/variables.py
+++ b/fastapi/app/api/api_v1/endpoints/variables.py
@@ -56,8 +56,6 @@ def get_timestep_item(gc, group_folder_id, timestep):
 
 
 def get_timestep_bp_file_id(gc, group_folder_id, group_name, timestep):
-    filename = f"{group_name}.bp.tgz"
-
     timestep_item = get_timestep_item(gc, group_folder_id, timestep)
 
     for bp_file in gc.listFile(timestep_item["_id"]):

--- a/fastapi/app/schemas/format.py
+++ b/fastapi/app/schemas/format.py
@@ -2,6 +2,6 @@ from enum import Enum
 
 
 class PlotFormat(str, Enum):
-    plotly = "lines"
+    plotly = ["lines", "bar", "scatter"]
     mesh = "mesh-colormap"
     colormap = "colormap"

--- a/ingest/esimmon/cli/watch/__init__.py
+++ b/ingest/esimmon/cli/watch/__init__.py
@@ -452,7 +452,8 @@ async def upload_timestep_bp_archive(
 async def fetch_variables(
     source: UploadSource, upload_url, shot_name, run_name, timestep
 ):
-    url = f"{upload_url}/shots/{shot_name}/{run_name}/{timestep}/variables.json"
+    # FIXME: Temp hack to handle wrong path. Revert once path is fixed.
+    url = f"{upload_url}/{shot_name}/{run_name}/{timestep}/variables.json"
 
     return await source.fetch_json(url)
 
@@ -460,7 +461,8 @@ async def fetch_variables(
 async def fetch_images_archive(
     source: UploadSource, upload_url, shot_name, run_name, timestep
 ):
-    url = f"{upload_url}/shots/{shot_name}/{run_name}/{timestep}/images.tar.gz"
+    # FIXME: Temp hack to handle wrong path. Revert once path is fixed.
+    url = f"{upload_url}/{shot_name}/{run_name}/{timestep}/images.tar.gz"
 
     return await source.fetch_binary(url)
 
@@ -599,7 +601,8 @@ async def fetch_images_scheduler(queue):
 
 
 async def fetch_run_time(source: UploadSource, upload_url, shot_name, run_name):
-    run_path = f"{upload_url}/shots/{shot_name}/{run_name}/time.json"
+    # FIXME: Temp hack to handle wrong path. Revert once path is fixed.
+    run_path = f"{upload_url}/{shot_name}/{run_name}/time.json"
 
     return await source.fetch_json(run_path)
 
@@ -636,7 +639,8 @@ async def watch_run(
                 last_timestep = 0
 
         # Now see where the simulation upload has got to
-        run_path = "shots/%s/%s/time.json" % (shot_name, run_name)
+        # FIXME: Temp hack to handle wrong path. Revert once path is fixed.
+        run_path = "%s/%s/time.json" % (shot_name, run_name)
         time = await fetch_run_time(source, upload_url, shot_name, run_name)
         # Wait for time.json to appear
         if time is None:
@@ -715,7 +719,8 @@ async def watch_run(
 
 
 async def fetch_shot_index(source: UploadSource, upload_url):
-    url = f"{upload_url}/shots/index.json"
+    # FIXME: Temp hack to handle wrong path. Revert once path is fixed.
+    url = f"{upload_url}/index.json"
     return await source.fetch_json(url)
 
 


### PR DESCRIPTION
In my testing this seems to work with the performance plots, but we don't have official data to test this with yet.

Currently testing with the `tauprofile-xgc-eem-cpp-gpu` data using a modified version of the [`adios2pandas`](https://github.com/dyokelson/adiosvm/blob/master/Tutorial/gray-scott/adios2pandas.py) script to generate bp files that should be pretty close to what we'd expect with the finalized output.

![cpu](https://user-images.githubusercontent.com/51238406/178592411-4ce65fa4-fe7a-4615-bbc1-ac4975aee3c6.gif)
![memory](https://user-images.githubusercontent.com/51238406/178592415-ee753eb4-9786-4b4f-bd45-18d7c6f5dbd1.gif)
