### PR TITLE
Transportation and Poincare plot support

### DIFF
--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -105,48 +105,6 @@ export default {
       }
     }, 100),
 
-    async getRangeData(event = null) {
-      if (_.isNull(this.location) || this.location._modelType != "folder")
-        return;
-
-      const folderId = this.location._id;
-      let img = null;
-      if (!this.cancel) {
-        if (event && !event.target.textContent) {
-          this.cancel = true;
-          return;
-        } else if (
-          !event ||
-          event.target.textContent.trim() == this.parameter
-        ) {
-          img = await this.callEndpoints(folderId);
-          if (img && img.data.data) this.updateRange(img.data.data[0].y, event);
-        }
-      }
-    },
-
-    async callEndpoints(folderId) {
-      if (!folderId) return;
-
-      var data = null;
-      var endpoint = `item?folderId=${folderId}&name=${this.parameter}&limit=50&sort=lowerName&sortdir=1`;
-      const itemId = await this.girderRest
-        .get(endpoint)
-        .then((result) => result.data[0]?._id);
-      if (itemId) {
-        var timeSteps = await this.girderRest
-          .get(`${this.fastRestUrl}/variables/${itemId}/timesteps`)
-          .then((results) => results.data.steps);
-        if (timeSteps.find((step) => step === this.currentTimeStep)) {
-          endpoint = `${this.fastRestUrl}/variables/${itemId}/timesteps/${this.currentTimeStep}/plot`;
-          data = await this.girderRest
-            .get(endpoint)
-            .then((response) => response.data);
-        }
-      }
-      return data;
-    },
-
     updateRange(yVals, event) {
       this.pos = event ? [event.clientX, event.clientY] : this.pos;
       this.range =

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -63,7 +63,6 @@ export default {
     itemId: {
       immediate: true,
       handler() {
-        this.setLoadedTimeStepData({ [`${this.itemId}`]: [] });
         this.prefetchRequested.clear();
         this.loadVariable();
       },

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -20,7 +20,8 @@ import vtkPolyData from "@kitware/vtk.js/Common/DataModel/PolyData";
 import vtkRenderer from "@kitware/vtk.js/Rendering/Core/Renderer";
 import vtkScalarBarActor from "@kitware/vtk.js/Rendering/Core/ScalarBarActor";
 
-const AXES_LABEL_BOUNDS_ADJUSTMENT = 0.3;
+const X_AXES_LABEL_BOUNDS_ADJUSTMENT = 0.3;
+const Y_AXES_LABEL_BOUNDS_ADJUSTMENT = 0.001;
 
 export default {
   name: "VTKPlot",
@@ -386,9 +387,12 @@ export default {
       // Update camera
       if (!this.zoom) {
         // TODO: Remove this when we have more functionality in VTK charts
-        // Hack to adjust the bounds to include the x label
         if (this.plotType === PlotType.Mesh) {
-          bounds[2] -= AXES_LABEL_BOUNDS_ADJUSTMENT;
+          // Hack to adjust the bounds to include the x label
+          bounds[2] -= X_AXES_LABEL_BOUNDS_ADJUSTMENT;
+        } else if (this.plotType === PlotType.Scatter) {
+          // Hack to adjust the bounds to include the y label
+          bounds[1] -= Y_AXES_LABEL_BOUNDS_ADJUSTMENT;
         }
         this.renderer.resetCamera(bounds);
         if (!this.position) {
@@ -616,11 +620,16 @@ export default {
       }
       if (!this.zoom) {
         const bounds = [...this.actor.getBounds()];
-        if (this.plotType === PlotType.Mesh) {
+        if (this.plotType !== PlotType.ColorMap) {
           this.camera.setPosition(...this.position);
           // Hack to adjust the bounds to include the x label
-          // This can be removed when vtk.js include the text labels in its bounds.
-          bounds[2] -= AXES_LABEL_BOUNDS_ADJUSTMENT;
+          if (this.plotType === PlotType.Mesh) {
+            // This can be removed when vtk.js include the text labels in its bounds.
+            bounds[2] -= X_AXES_LABEL_BOUNDS_ADJUSTMENT;
+          } else if (this.plotType === PlotType.Scatter) {
+            // This can be removed when vtk.js include the text labels in its bounds.
+            bounds[1] -= Y_AXES_LABEL_BOUNDS_ADJUSTMENT;
+          }
         }
         this.renderer.resetCamera(bounds);
         this.rangeText = [];

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -49,6 +49,7 @@ export default {
       position: null,
       rangeText: [],
       plotType: null,
+      newPlotLoaded: false,
     };
   },
 
@@ -137,10 +138,11 @@ export default {
     },
     itemId: {
       immediate: true,
-      handler(val) {
-        if (!val) {
+      handler(new_id, old_id) {
+        if (!new_id) {
           this.removeRenderer();
         }
+        this.newPlotLoaded = new_id !== old_id;
       },
     },
   },
@@ -222,16 +224,16 @@ export default {
       });
     },
     addRenderer(data) {
+      if (this.renderer && !this.newPlotLoaded) {
+        // We've already created a renderer, just re-use it
+        return;
+      }
+
       if (this.renderer) {
-        if (this.plotType !== data.type) {
-          // Connectivity is handled differently for different plots
-          // Recreate the renderer for new plot types
-          this.removeRenderer();
-          this.plotType = data.type;
-        } else {
-          // We've already created a renderer, just re-use it
-          return;
-        }
+        // Connectivity is handled differently for different plots
+        // Recreate the renderer for new plot types
+        this.removeRenderer();
+        this.newPlotLoaded = false;
       }
 
       this.plotType = data.type;

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -3,4 +3,5 @@ export const PlotType = {
   VTK: "vtk",
   Mesh: "mesh-colormap",
   ColorMap: "colormap",
+  Scatter: "scatter",
 };

--- a/fastapi/app/api/api_v1/endpoints/images.py
+++ b/fastapi/app/api/api_v1/endpoints/images.py
@@ -48,12 +48,18 @@ router = APIRouter()
 
 def create_plotly_image(plot_data: dict, format: str, details: dict):
     # The json contains Javascript syntax. Update values for Python
-    for data in plot_data["data"]:
-        data["mode"] = "lines"
+    plot_type = plot_data["type"]
+    if plot_type != "bar":
+        mode = "lines" if plot_type == "lines" else "markers"
+        for data in plot_data["data"]:
+            data["mode"] = mode
+
     plot_data["layout"]["autosize"] = True
     plot_data["layout"]["xaxis"]["automargin"] = True
     plot_data["layout"]["yaxis"]["automargin"] = True
     plot_data["layout"]["title"]["x"] = 0.5
+    # TODO: Find the best solution for legengs that take up too much space
+    # plot_data["layout"]["showlegend"] = False
     plot_data["layout"].pop("name", None)
     plot_data["layout"].pop("frames", None)
     if details:
@@ -326,7 +332,7 @@ def create_mesh_image(plot_data: dict, format: str, details: dict):
 
 
 async def get_timestep_image_data(plot: dict, format: str, details: dict):
-    if plot["type"] == PlotFormat.plotly:
+    if plot["type"] in PlotFormat.plotly:
         image = create_plotly_image(plot, format, details)
     elif plot["type"] == PlotFormat.mesh or plot["type"] == PlotFormat.colormap:
         image = create_mesh_image(plot, format, details)

--- a/fastapi/app/api/api_v1/endpoints/plotly.py
+++ b/fastapi/app/api/api_v1/endpoints/plotly.py
@@ -4,28 +4,28 @@ import numpy as np
 from fastapi.responses import JSONResponse
 
 
-def generate_js_data(x: np.ndarray, y: np.ndarray, name: str):
-    return {
+def generate_data(x: np.ndarray, y: np.ndarray, name: str, plot_type: str):
+    data = {
         "name": name,
-        "mode": "line",
         "type": "scatter",
         "x": x,
         "y": y,
     }
+    if plot_type == "bar":
+        data["type"] = "bar"
+    else:
+        if plot_type == "lines":
+            mode = "lines"
+        elif plot_type == "scatter":
+            mode = "markers"
+        data["mode"] = mode
+    return data
 
 
-def generate_python_data(x: np.ndarray, y: np.ndarray, name: str):
-    return {
-        "name": name,
-        "mode": "lines",
-        "type": "scatter",
-        "x": x,
-        "y": y,
-    }
-
-
-def generate_js_layout(title: str, x_label: str, y_label: str, name: str):
-    return {
+def generate_js_layout(
+    title: str, x_label: str, y_label: str, name: str, plot_type: str
+):
+    layout = {
         "autosize": "true",
         "hovermode": "closest",
         "margin": {"l": 60, "t": 30, "b": 30, "r": 10},
@@ -42,11 +42,16 @@ def generate_js_layout(title: str, x_label: str, y_label: str, name: str):
         },
         "frames": [],
         "name": name,
+        "legend": {"display": "false"},
+        "showlegend": "false",
     }
+    if plot_type == "bar":
+        layout["barmode"] = "stack"
+    return layout
 
 
-def generate_python_layout(title: str, x_label: str, y_label: str):
-    return {
+def generate_python_layout(title: str, x_label: str, y_label: str, plot_type: str):
+    layout = {
         "autosize": True,
         "hovermode": "closest",
         "margin": {"l": 60, "t": 30, "b": 30, "r": 10},
@@ -62,6 +67,9 @@ def generate_python_layout(title: str, x_label: str, y_label: str):
             "automargin": True,
         },
     }
+    if plot_type == "bar":
+        layout["barmode"] = "stack"
+    return layout
 
 
 async def generate_plotly_response(plot_config: Dict, bp_file, variable: str):
@@ -70,18 +78,23 @@ async def generate_plotly_response(plot_config: Dict, bp_file, variable: str):
     y_variables = plot_config["y"]
     y_names = plot_config["yname"]
     y_label = plot_config["ylabel"]
+    plot_type = plot_config["type"]
 
     data = []
     x = bp_file.read(x_variable).tolist()
 
     for (y_variable, y_name) in zip(y_variables, y_names):
         y = bp_file.read(y_variable).tolist()
-        data.append(generate_js_data(x, y, y_name)),
+        data.append(generate_data(x, y, y_name, plot_type)),
 
     plotly_json = {
         "data": data,
         "layout": generate_js_layout(
-            title=variable, x_label=x_label, y_label=y_label, name=variable
+            title=variable,
+            x_label=x_label,
+            y_label=y_label,
+            name=variable,
+            plot_type=plot_type,
         ),
         "type": "plotly",
     }
@@ -97,20 +110,21 @@ async def generate_plotly_data(plot_config: Dict, bp_file, variable: str):
     y_variables = plot_config["y"]
     y_names = plot_config["yname"]
     y_label = plot_config["ylabel"]
+    plot_type = plot_config["type"]
 
     data = []
     x = bp_file.read(x_variable).tolist()
 
     for (y_variable, y_name) in zip(y_variables, y_names):
         y = bp_file.read(y_variable).tolist()
-        data.append(generate_python_data(x, y, y_name)),
+        data.append(generate_data(x, y, y_name, plot_type)),
 
     plotly_json = {
         "data": data,
         "layout": generate_python_layout(
-            title=variable, x_label=x_label, y_label=y_label
+            title=variable, x_label=x_label, y_label=y_label, plot_type=plot_type
         ),
-        "type": "lines",
+        "type": plot_type,
     }
 
     return plotly_json

--- a/fastapi/app/api/api_v1/endpoints/scatter.py
+++ b/fastapi/app/api/api_v1/endpoints/scatter.py
@@ -1,0 +1,27 @@
+from typing import Dict
+
+from .utils import MsgpackResponse
+
+
+async def generate_scatter_data(plot_config: Dict, bp_file, variable: str):
+    x_variable = plot_config["x"]
+    x_label = plot_config["xlabel"]
+    y_variable = plot_config["y"]
+    y_label = plot_config["ylabel"]
+
+    x = bp_file.read(x_variable).data
+    y = bp_file.read(y_variable).data
+
+    return {
+        "x": x,
+        "y": y,
+        "xLabel": x_label,
+        "yLabel": y_label,
+        "type": "scatter",
+        "title": variable,
+    }
+
+
+async def generate_scatter_response(plot_config: Dict, bp_file, variable: str):
+    scatter_json = await generate_scatter_data(plot_config, bp_file, variable)
+    return MsgpackResponse(content=scatter_json)

--- a/fastapi/app/api/api_v1/endpoints/variables.py
+++ b/fastapi/app/api/api_v1/endpoints/variables.py
@@ -89,8 +89,7 @@ async def generate_plot_response(bp, variable: str):
     plot_config = json.loads(plot_config[0])
 
     plot_type = plot_config["type"]
-
-    if plot_type == PlotFormat.plotly:
+    if plot_type in PlotFormat.plotly:
         return await generate_plotly_response(plot_config, bp, variable)
     elif plot_type == PlotFormat.mesh:
         return await generate_mesh_response(plot_config, bp, variable)
@@ -106,7 +105,7 @@ async def generate_plot_data(bp, variable: str):
 
     plot_type = plot_config["type"]
 
-    if plot_type == PlotFormat.plotly:
+    if plot_type in PlotFormat.plotly:
         return await generate_plotly_data(plot_config, bp, variable)
     elif plot_type == PlotFormat.mesh:
         return await generate_mesh_data(plot_config, bp, variable)

--- a/fastapi/app/api/api_v1/endpoints/variables.py
+++ b/fastapi/app/api/api_v1/endpoints/variables.py
@@ -56,8 +56,6 @@ def get_timestep_item(gc, group_folder_id, timestep):
 
 
 def get_timestep_bp_file_id(gc, group_folder_id, group_name, timestep):
-    filename = f"{group_name}.bp.tgz"
-
     timestep_item = get_timestep_item(gc, group_folder_id, timestep)
 
     for bp_file in gc.listFile(timestep_item["_id"]):

--- a/fastapi/app/api/api_v1/endpoints/variables.py
+++ b/fastapi/app/api/api_v1/endpoints/variables.py
@@ -16,6 +16,8 @@ from .mesh import generate_mesh_data
 from .mesh import generate_mesh_response
 from .plotly import generate_plotly_data
 from .plotly import generate_plotly_response
+from .scatter import generate_scatter_data
+from .scatter import generate_scatter_response
 from .utils import get_girder_client
 
 router = APIRouter()
@@ -58,6 +60,13 @@ def get_timestep_item(gc, group_folder_id, timestep):
 def get_timestep_bp_file_id(gc, group_folder_id, group_name, timestep):
     timestep_item = get_timestep_item(gc, group_folder_id, timestep)
 
+    # FIXME: This is a temporary hack to allow us to test the performance plots
+    # This block should be removed once those bp filenames are fixed.
+    if group_name == "HeatLoad" or group_name == "Poincare":
+        filename = f"{group_name}-{timestep_item['name'].lstrip('0')}.bp.tgz"
+    else:
+        filename = f"{group_name}.bp.tgz"
+
     for bp_file in gc.listFile(timestep_item["_id"]):
         if bp_file["name"] == filename:
             return bp_file["_id"]
@@ -93,6 +102,8 @@ async def generate_plot_response(bp, variable: str):
         return await generate_mesh_response(plot_config, bp, variable)
     elif plot_type == PlotFormat.colormap:
         return await generate_colormap_response(plot_config, bp, variable)
+    elif plot_type == PlotFormat.scatter:
+        return await generate_scatter_response(plot_config, bp, variable)
 
     raise HTTPException(status_code=400, detail="Unsupported plot type.")
 
@@ -109,6 +120,8 @@ async def generate_plot_data(bp, variable: str):
         return await generate_mesh_data(plot_config, bp, variable)
     elif plot_type == PlotFormat.colormap:
         return await generate_colormap_data(plot_config, bp, variable)
+    elif plot_type == PlotFormat.scatter:
+        return await generate_scatter_data(plot_config, bp, variable)
 
     raise HTTPException(status_code=400, detail="Unsupported plot type.")
 

--- a/fastapi/app/schemas/format.py
+++ b/fastapi/app/schemas/format.py
@@ -2,6 +2,6 @@ from enum import Enum
 
 
 class PlotFormat(str, Enum):
-    plotly = "lines"
+    plotly = ["lines", "bar", "scatter"]
     mesh = "mesh-colormap"
     colormap = "colormap"

--- a/fastapi/app/schemas/format.py
+++ b/fastapi/app/schemas/format.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class PlotFormat(str, Enum):
-    plotly = ["lines", "bar", "scatter"]
+    plotly = ["lines", "bar"]
     mesh = "mesh-colormap"
     colormap = "colormap"
+    scatter = "scatter"


### PR DESCRIPTION
Adds support for transportation and Poincare plots.

Transportation plots:

![transportation_plots](https://user-images.githubusercontent.com/51238406/193633880-f8d1bb4f-a504-44b7-af0c-160becd9a0d1.gif)

Poincare:

![poincare_plots](https://user-images.githubusercontent.com/51238406/193633903-38666331-f184-4662-8dd3-cc892cbf16db.gif)

There is some weird behavior for the axes for the `RZ` parameter, but this does not happen with the flux plots or `ThetaPsi` parameter (which have the same hacks applied to them to fix the plot ratio and adjust the axes actor). I will need to dig into this behavior more. 