### PR TITLE
Cleanup plot appearances

### DIFF
--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -290,6 +290,13 @@ export default {
     loadAutoSavedView() {
       this.loadAutoSave();
     },
+
+    adjustRenderWindowWidth(event) {
+      const navPanel = event[0].size;
+      const rw = document.getElementById("renderWindow");
+      rw.style.width = `${100 - navPanel}%`;
+      this.$refs.renderWindow.resize();
+    },
   },
 
   asyncComputed: {

--- a/client/src/components/core/App/template.html
+++ b/client/src/components/core/App/template.html
@@ -7,7 +7,7 @@
     />
   </v-dialog>
   <context-menu />
-  <splitpanes>
+  <splitpanes @resize="adjustRenderWindowWidth">
     <pane min-size="15" :size="25">
       <v-row v-bind:style="{height: '100vh'}">
         <!-- Navigation panel on the left. -->
@@ -140,7 +140,7 @@
       v-on:mouseover.native="hoverOut"
     >
       <!-- image gallery grid. -->
-      <render-window class="plots" />
+      <render-window ref="renderWindow" id="renderWindow" class="plots" />
       <v-container v-bind:style="{padding: '0', maxWidth: '100%'}">
         <template v-for="i in numrows">
           <v-row v-bind:key="i">

--- a/client/src/components/core/ViewControls/template.html
+++ b/client/src/components/core/ViewControls/template.html
@@ -59,7 +59,7 @@
     <save-dialog :layout="plots" @close="setSaveDialogVisible(false)" />
     <load-dialog @close="setLoadDialogVisible(false)" />
   </v-row>
-  <v-row v-if="lastSaved">
+  <v-row v-show="lastSaved">
     <span v-bind:style="{fontSize: 'small', opacity: '0.5'}">
       View Autosaved: {{ new Date(lastSaved).toLocaleTimeString() }}
     </span>

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -195,7 +195,22 @@ export default {
           (x - parent.x + width) / parent.width,
           1 - y / parent.height,
         ];
-        this.renderer.setViewport(...viewport);
+        if (this.plotType === PlotType.Mesh) {
+          this.renderer.setViewport(...viewport);
+        } else {
+          // Keep the viewport square for square plots
+          const h = viewport[3] - viewport[1];
+          const w = viewport[2] - viewport[0];
+          const midx = w / 2 + viewport[0];
+          const midy = h / 2 + viewport[1];
+          let size = h > w ? w / 2 : h / 2;
+          this.renderer.setViewport(
+            midx - size,
+            midy - size,
+            midx + size,
+            midy + size
+          );
+        }
       });
     },
     addRenderer(data) {

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -291,6 +291,7 @@ export default {
       this.scalarBar.setAxisTextStyle({ fontColor: "black" });
       this.scalarBar.setTickTextStyle({ fontColor: "black" });
       this.scalarBar.setDrawNanAnnotation(false);
+      this.scalarBar.setAutoLayout(scalarBarAutoLayout(this.scalarBar));
       this.renderer.addActor2D(this.scalarBar);
 
       // Setup picker

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -72,7 +72,7 @@
   flex-flow: column;
   max-height: 240px;
   min-height: 240px;
-  overflow: auto;
+  overflow: hidden;
   padding-bottom: 0;
   .row {
     justify-content: space-around;

--- a/client/src/utils/vtkPlotStyling.js
+++ b/client/src/utils/vtkPlotStyling.js
@@ -83,20 +83,9 @@ export function scalarBarAutoLayout(model) {
       (2.0 * (textSizes.titleHeight + helper.getAxisTitlePixelOffset())) /
       lastSize[0];
 
-    // if the title will fit within the width of the bar then that looks
-    // nicer to put it at the top (helper.topTitle), otherwise rotate it
-    // and place it sideways
-    if (
-      tickWidth + 0.4 * titleWidth >
-      (2.0 * textSizes.titleWidth) / lastSize[0]
-    ) {
-      helper.setTopTitle(true);
-      boxSize[0] = tickWidth + 0.4 * titleWidth;
-      helper.setBoxPosition([0.98 - boxSize[0], -0.92]);
-    } else {
-      boxSize[0] = tickWidth + 1.4 * titleWidth;
-      helper.setBoxPosition([0.99 - boxSize[0], -0.92]);
-    }
+    // Rotate the title and place it sideways
+    boxSize[0] = tickWidth + 1.4 * titleWidth;
+    helper.setBoxPosition([0.99 - boxSize[0], -0.92]);
     boxSize[1] = Math.max(1.2, Math.min(1.84 / yAxisAdjust, 1.84));
 
     // recomute bar segments based on positioning


### PR DESCRIPTION
This cleans up a handful of appearance/layout issues:
- Prevent overlapping plots/scalarbars in VTK plots by enforcing a square viewport for our scaled (square) plots
- Resize the render window when the navigation panel is resized (otherwise VTK plots flow out of their cell)
- Resize the control panel to prevent flickering when updated (Fixes #172)
- Use consistent styling for the scalarbar in VTK plots (all titles are vertical now to avoid wasted space created by horizontal titles)