### PR TITLE
Hide the Plotly legends by default

### DIFF
--- a/client/src/components/widgets/PlotlyPlot/script.js
+++ b/client/src/components/widgets/PlotlyPlot/script.js
@@ -60,6 +60,12 @@ export default {
       }
       return this.allAvailableTimeSteps[`${this.itemId}`] || [];
     },
+    legendVisibility() {
+      if (!this.itemId || !this.plotDetails) {
+        return false;
+      }
+      return this.plotDetails[`${this.itemId}`]?.legend;
+    },
     loadedTimeStepData() {
       if (!this.allLoadedTimeStepData) {
         return [];
@@ -108,6 +114,12 @@ export default {
       handler() {
         this.react();
         this.$nextTick(this.relayoutPlotly);
+      },
+    },
+    legendVisibility: {
+      immediate: true,
+      handler() {
+        this.react();
       },
     },
     logScaling: {
@@ -183,6 +195,7 @@ export default {
         nextImage.layout.xaxis.type = this.logScaling ? "log" : "linear";
         nextImage.layout.yaxis.type = this.logScaling ? "log" : "linear";
         nextImage.layout.yaxis.autorange = true;
+        nextImage.layout.showlegend = this.legendVisibility;
         if (this.zoom) {
           nextImage.layout.xaxis.range = this.zoom.xAxis;
           nextImage.layout.yaxis.range = this.zoom.yAxis;
@@ -201,8 +214,13 @@ export default {
               icon: Plotly.Icons["3d_rotate"],
               click: this.toggleLogScale,
             },
+            {
+              name: "toggle legend visibility",
+              icon: Plotly.Icons["autoscale"],
+              click: this.toggleLegendVisibility,
+            },
           ],
-          modeBarButtonsToRemove: ["toImage"],
+          modeBarButtonsToRemove: ["toImage", "autoScale2d"],
         });
         if (!this.eventHandlersSet) this.setEventHandlers();
         this.updateNumReady(this.numReady + 1);
@@ -298,6 +316,11 @@ export default {
     },
     toggleLogScale() {
       this.updatePlotDetails({ [`${this.itemId}`]: { log: !this.logScaling } });
+    },
+    toggleLegendVisibility() {
+      this.updatePlotDetails({
+        [`${this.itemId}`]: { legend: !this.legendVisibility },
+      });
     },
   },
 

--- a/client/src/components/widgets/PlotlyPlot/script.js
+++ b/client/src/components/widgets/PlotlyPlot/script.js
@@ -216,11 +216,11 @@ export default {
             },
             {
               name: "toggle legend visibility",
-              icon: Plotly.Icons["autoscale"],
+              icon: Plotly.Icons["tooltip_basic"],
               click: this.toggleLegendVisibility,
             },
           ],
-          modeBarButtonsToRemove: ["toImage", "autoScale2d"],
+          modeBarButtonsToRemove: ["toImage"],
         });
         if (!this.eventHandlersSet) this.setEventHandlers();
         this.updateNumReady(this.numReady + 1);

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -206,7 +206,13 @@ export default {
       );
       this.itemId = items[0]._id;
       this.updatePlotDetails({
-        [`${this.itemId}`]: { zoom: null, log: false, xAxis: "", range: null },
+        [`${this.itemId}`]: {
+          zoom: null,
+          log: false,
+          xAxis: "",
+          range: null,
+          legend: false,
+        },
       });
       this.setLoadedFromView(false);
       this.setRun();
@@ -222,6 +228,7 @@ export default {
           log: item.log,
           xAxis: item.xAxis,
           range: item.range,
+          legend: item.legend,
         },
       });
     },

--- a/client/src/store/views.js
+++ b/client/src/store/views.js
@@ -182,8 +182,16 @@ export default {
       const plotDetails = getters.PLOT_DETAILS;
       layout.forEach((item) => {
         const { row, col } = item;
-        const { log, range, xAxis, zoom } = plotDetails[`${item.itemId}`];
-        items[`${row}::${col}`] = { id: item.itemId, log, range, xAxis, zoom };
+        const { legend, log, range, xAxis, zoom } =
+          plotDetails[`${item.itemId}`];
+        items[`${row}::${col}`] = {
+          id: item.itemId,
+          legend,
+          log,
+          range,
+          xAxis,
+          zoom,
+        };
       });
       commit("VIEW_ITEMS_SET", items);
     },

--- a/fastapi/app/api/api_v1/endpoints/images.py
+++ b/fastapi/app/api/api_v1/endpoints/images.py
@@ -65,6 +65,8 @@ def create_plotly_image(plot_data: dict, format: str, details: dict):
         if zoom:
             plot_data["layout"]["xaxis"]["range"] = details["zoom"]["xAxis"]
             plot_data["layout"]["yaxis"]["range"] = details["zoom"]["yAxis"]
+        legend = details.get("legend", False)
+        plot_data["layout"]["showlegend"] = legend
 
     # Get image as bytes
     fig = go.Figure(plot_data["data"], plot_data["layout"])


### PR DESCRIPTION
Adds the ability to toggle the visibility of the legends on Plotly plots. Defaults to hidden.

![plotly-legends](https://user-images.githubusercontent.com/51238406/196058408-4afe2f1c-29b9-4348-abcf-3ed66262b1e4.gif)

Fizes #145 