### PR TITLE
Bugs

### DIFF
--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -279,7 +279,6 @@ export default {
       minTimeStep: "PLOT_MIN_TIME_STEP",
       viewTimeStep: "PLOT_VIEW_TIME_STEP",
       numReady: "PLOT_NUM_READY",
-      selectedPlots: "PLOT_SELECTIONS",
     }),
 
     location: {
@@ -401,22 +400,6 @@ export default {
 
       // Setup polling to autosave view
       this.autosave();
-    },
-
-    selectedPlots(selections) {
-      const dataTable = document.getElementById("data-table");
-      if (!dataTable) {
-        return;
-      }
-      const tableBody = dataTable.getElementsByTagName("tbody")[0];
-      const children = tableBody.childNodes;
-      children.forEach((child) => {
-        if (selections.includes(child.id)) {
-          child.style.color = "lightgray";
-        } else {
-          child.style.color = "black";
-        }
-      });
     },
   },
 };

--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -116,7 +116,13 @@ export default {
     },
 
     updateTimeStep(val) {
-      this.setCurrentTimeStep(parseInt(val));
+      if (this.minTimeStep <= val && val <= this.maxTimeStep) {
+        this.setCurrentTimeStep(parseInt(val));
+      } else if (this.minTimeStep > val) {
+        this.setCurrentTimeStep(this.minTimeStep);
+      } else {
+        this.setCurrentTimeStep(this.maxTimeStep);
+      }
     },
 
     incrementTimeStep(should_pause) {

--- a/client/src/components/core/App/template.html
+++ b/client/src/components/core/App/template.html
@@ -45,7 +45,7 @@
               <v-col :sm="1" class="text-xs-center">
                 <v-icon
                   v-on:click="decrementTimeStep(true)"
-                  :disabled="!dataLoaded"
+                  :disabled="!dataLoaded || currentTimeStep === minTimeStep"
                 >
                   arrow_back_ios
                 </v-icon>
@@ -63,7 +63,7 @@
               <v-col :sm="1" class="text-xs-center">
                 <v-icon
                   v-on:click="incrementTimeStep(true)"
-                  :disabled="!dataLoaded"
+                  :disabled="!dataLoaded || currentTimeStep === maxTimeStep"
                 >
                   arrow_forward_ios
                 </v-icon>
@@ -89,7 +89,7 @@
               <v-col :sm="6" class="text-xs-center">
                 <input
                   type="number"
-                  min="1"
+                  min="minTimeStep"
                   :max="maxTimeStep"
                   size="4"
                   :disabled="!dataLoaded"

--- a/client/src/components/widgets/GirderDataTable/script.js
+++ b/client/src/components/widgets/GirderDataTable/script.js
@@ -3,7 +3,21 @@ This component extends the DataTable component in order to set the id on the
 row elements.
 */
 import { GirderDataTable } from "@girder/components/src";
+import { mapGetters } from "vuex";
 
 export default {
   mixins: [GirderDataTable],
+
+  computed: {
+    ...mapGetters({
+      selectedPlots: "PLOT_SELECTIONS",
+    }),
+  },
+
+  methods: {
+    selectedPlot(id) {
+      const color = this.selectedPlots.includes(id) ? "lightgray" : "black";
+      return { color };
+    },
+  },
 };

--- a/client/src/components/widgets/GirderDataTable/template.html
+++ b/client/src/components/widgets/GirderDataTable/template.html
@@ -25,6 +25,7 @@
       :active="props.isSelected"
       :class="getRowClass(props.item)"
       class="itemRow"
+      :style="selectedPlot(props.item._id)"
       @click="handleRowSelect($event, props)"
       @drag="emitDrag('drag', $event, [props])"
       @dragstart="emitDrag('dragstart', $event, [props])"

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -77,7 +77,7 @@ export default {
 
   methods: {
     ...mapActions({
-      setMinTimeStep: "PLOT_MIN_TIME_STEP_CHANGED",
+      updateMinTimeStep: "PLOT_MIN_TIME_STEP_CHANGED",
       updateTimes: "PLOT_UPDATE_ITEM_TIMES",
       setLoadedTimeStepData: "PLOT_UPDATE_LOADED_TIME_STEPS",
       setAvailableTimeSteps: "PLOT_UPDATE_AVAILABLE_TIME_STEPS",
@@ -177,7 +177,7 @@ export default {
         ats = response.steps.sort();
         this.setAvailableTimeSteps({ [`${this.itemId}`]: ats });
         this.updateTimes({ [`${this.itemId}`]: response.time });
-        this.setMinTimeStep(Math.max(this.minTimeStep, Math.min(...ats)));
+        this.updateMinTimeStep();
         // Make sure there is an image associated with this time step
         let step = ats.find((step) => step === this.currentTimeStep);
         if (isNil(step)) {

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -71,7 +71,6 @@ export default {
       immediate: true,
       handler() {
         this.prefetchRequested.clear();
-        this.loadVariable();
       },
     },
   },

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -148,7 +148,6 @@ export default {
 
   methods: {
     ...mapActions({
-      setMinTimeStep: "PLOT_MIN_TIME_STEP_CHANGED",
       updatePlotDetails: "PLOT_DETAILS_UPDATED",
     }),
     ...mapMutations({

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -191,9 +191,11 @@ export default {
       this.updateNumReady(this.numReady + 1);
     },
     updateViewPort() {
-      if (!this.renderer) return;
-
       this.$nextTick(() => {
+        if (!this.renderer) {
+          return;
+        }
+
         const parent = document
           .getElementById("mainContent")
           .getBoundingClientRect();

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -313,7 +313,9 @@ export default {
       this.mesh.getPolys().setData(cells);
     },
     updateRenderer(data) {
-      if (!this.renderer || !this.plotType) return;
+      if (!this.renderer || !this.plotType || this.plotType != data.type) {
+        return;
+      }
 
       if (this.plotType === PlotType.Mesh) {
         this.updateMeshRenderer(data);

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -50,7 +50,6 @@ export default {
       position: null,
       rangeText: [],
       plotType: null,
-      newPlotLoaded: false,
     };
   },
 
@@ -140,10 +139,9 @@ export default {
     itemId: {
       immediate: true,
       handler(new_id, old_id) {
-        if (!new_id) {
+        if (!new_id || new_id !== old_id) {
           this.removeRenderer();
         }
-        this.newPlotLoaded = new_id !== old_id;
       },
     },
   },
@@ -225,16 +223,9 @@ export default {
       });
     },
     addRenderer(data) {
-      if (this.renderer && !this.newPlotLoaded) {
+      if (this.renderer && this.plotType == data.type) {
         // We've already created a renderer, just re-use it
         return;
-      }
-
-      if (this.renderer) {
-        // Connectivity is handled differently for different plots
-        // Recreate the renderer for new plot types
-        this.removeRenderer();
-        this.newPlotLoaded = false;
       }
 
       this.plotType = data.type;

--- a/client/src/store/plots.js
+++ b/client/src/store/plots.js
@@ -125,9 +125,14 @@ export default {
     },
   },
   actions: {
-    PLOT_MIN_TIME_STEP_CHANGED({ state, commit }, val) {
-      commit("PLOT_MIN_TIME_STEP_SET", val);
-      commit("PLOT_TIME_STEP_SET", Math.max(state.currentTimeStep, val));
+    PLOT_MIN_TIME_STEP_CHANGED({ state, commit }) {
+      let newMin = Infinity;
+      Object.values(state.availableTimeSteps).forEach((ats) => {
+        const itemMin = Math.min(...ats);
+        newMin = itemMin < newMin ? itemMin : newMin;
+      });
+      commit("PLOT_MIN_TIME_STEP_SET", newMin);
+      commit("PLOT_TIME_STEP_SET", Math.max(state.currentTimeStep, newMin));
     },
     PLOT_UPDATE_ITEM_TIMES({ state, commit }, data) {
       let itemId = Object.keys(data)[0];


### PR DESCRIPTION
- Remove the renderer when `itemId`s do not match
  - Plot has been replaced
- Guard against removed renderer
  - If we're in the middle of loading a new plot by the time `nextTick` is hit we shouldn't try to update the viewport. Check for renderer on `nextTick` rather than checking immediately.
- Add an extra guard on plot update
  - If new plots are being added quickly enough `updateRenderer` may be called before the `plotType` has been updated. This wasn't preventing the correct plots from loading but it was producing errors in the console.
- Do not need to re-load variable if the max time step changes
  - Carried over from older code but this is no longer necessary 
- Fix min time step setter to use smaller value
  - Min time step was not being calculated correctly
- Update selected plots highlighting on navigation
  - Style the selected plot in the data table so that styling is not lost when navigating around
- Prevent user from setting a time step outside of range