### PR TITLE
Plot loading bugs

### DIFF
--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -194,14 +194,12 @@ export default {
           }
           return step;
         });
-      if (!this.isTimeStepLoaded(firstAvailableStep)) {
-        await this.fetchTimeStepData(firstAvailableStep);
+      await this.fetchTimeStepData(firstAvailableStep);
 
-        this.setMaxTimeStep(Math.max(this.maxTimeStep, Math.max(...ats)));
-        this.setItemId(this.itemId);
-        this.setInitialLoad(false);
-        return await this.$refs[`${this.row}-${this.col}`].react();
-      }
+      this.setMaxTimeStep(Math.max(this.maxTimeStep, Math.max(...ats)));
+      this.setItemId(this.itemId);
+      this.setInitialLoad(false);
+      this.$refs[`${this.row}-${this.col}`].react();
     },
     loadGallery: function (event) {
       this.preventDefault(event);

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -248,7 +248,7 @@ export default {
       }
       const ats = this.availableTimeSteps();
       const previousTimeStep = ats.findIndex((step) => step < timestep);
-      return previousTimeStep !== -1 ? ats[previousTimeStep] : null;
+      return previousTimeStep !== -1 ? ats[previousTimeStep] : ats[0];
     },
     /**
      * Return the next valid timestep, null if no timestep exists.

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -203,10 +203,13 @@ export default {
     },
     loadGallery: function (event) {
       this.preventDefault(event);
-      this.cleanUpOldPlotData();
       var items = JSON.parse(
         event.dataTransfer.getData("application/x-girder-items")
       );
+      if (items[0]._modelType !== "item") {
+        return;
+      }
+      this.cleanUpOldPlotData();
       const oldId = this.itemId;
       this.itemId = items[0]._id;
       this.updatePlotDetails({

--- a/client/src/store/plots.js
+++ b/client/src/store/plots.js
@@ -131,6 +131,9 @@ export default {
         const itemMin = Math.min(...ats);
         newMin = itemMin < newMin ? itemMin : newMin;
       });
+      if (state.maxTimeStep < newMin) {
+        commit("PLOT_MAX_TIME_STEP_SET", newMin);
+      }
       commit("PLOT_MIN_TIME_STEP_SET", newMin);
       if (!state.loadedFromView || !state.initialLoad) {
         commit("PLOT_TIME_STEP_SET", Math.max(state.currentTimeStep, newMin));


### PR DESCRIPTION
Fixes the following bugs:
- If the same VTK plot was added more than once the second plot was not rendered. This was because the plot type was not being set (we were not re-fetching the data and therefore not resetting the plot type) and the default type is Plotly, so the react() function was being called for the wrong plot type and nothing was rendered.
- If we moved back in time to a time step before the first available for a plot that plot remained at its current time step rather than moving back to the first available.
- Dropping collections/folders/etc should have no effect but they were being processed as items which would fail to update properly, creating bugs.
- The slider would always look weird on initial data load because the min value was being set before the max, so the slider would have a larger min that max value.