### PR TITLE
Simplify containers

### DIFF
--- a/client/src/bootstrap.js
+++ b/client/src/bootstrap.js
@@ -2,7 +2,6 @@ import Vue from "vue";
 import App from "./components/core/App";
 import Vuex from "vuex";
 import Girder, { RestClient, vuetify } from "@girder/components/src";
-import { isNil } from "lodash";
 import VueMathjax from "vue-mathjax";
 import store from "./store";
 
@@ -18,13 +17,19 @@ export function bootstrap() {
     fastRestUrl = `http://localhost:5000/api/v1`;
   }
 
-  let folderId = null;
-  if (!isNil(process.env.VUE_APP_FOLDER_ID)) {
-    folderId = process.env.VUE_APP_FOLDER_ID;
-  }
-
+  const defaultLocation = { _modelType: "folder", _id: null };
   const girderRest = new RestClient({ apiRoot, authenticateWithCredentials });
-  const defaultLocation = { _modelType: "folder", _id: folderId };
+  girderRest.get("/collection?text=eSimMon").then((collections) => {
+    // The dashboard will always use the eSimMon collection to collect all data
+    let id = collections.data[0]._id;
+    girderRest
+      .get(`/folder?parentType=collection&parentId=${id}`)
+      .then((folders) => {
+        // The eSimMon collection should have a single folder that contains all
+        // data and serves as the top-level directory.
+        defaultLocation._id = folders.data[0]._id;
+      });
+  });
 
   Vue.config.productionTip = false;
   Vue.use(Vuex);

--- a/client/src/bootstrap.js
+++ b/client/src/bootstrap.js
@@ -12,14 +12,10 @@ export function bootstrap() {
 
   let apiRoot = `${window.location}api/v1`;
   let authenticateWithCredentials = false;
-  if (!isNil(process.env.VUE_APP_API_URL)) {
-    apiRoot = process.env.VUE_APP_API_URL;
-    authenticateWithCredentials = true;
-  }
 
-  var fastRestUrl = `http://localhost:5000/api/v1`;
-  if (!isNil(process.env.VUE_APP_FASTAPI_API_URL)) {
-    fastRestUrl = process.env.VUE_APP_FASTAPI_API_URL;
+  var fastRestUrl = apiRoot;
+  if (window.location.host === "esimmon.kitware.com") {
+    fastRestUrl = `http://localhost:5000/api/v1`;
   }
 
   let folderId = null;

--- a/devops/ansible/site.yml
+++ b/devops/ansible/site.yml
@@ -203,16 +203,3 @@
         regexp: "^GIRDER_FOLDER_ID="
         line: "GIRDER_FOLDER_ID={{ data_folder.gc_return._id }}"
       when: not folder_presence.matched
-
-    - name: Check if folder ID has already been set for client
-      find:
-        paths: ../docker/
-        contains: "^VUE_APP_FOLDER_ID="
-      register: client_folder_presence
-
-    - name: Save folder ID if not set
-      lineinfile:
-        dest: ../docker/.env
-        regexp: "^VUE_APP_FOLDER_ID="
-        line: "VUE_APP_FOLDER_ID={{ data_folder.gc_return._id }}"
-      when: not client_folder_presence.matched

--- a/devops/docker/.env
+++ b/devops/docker/.env
@@ -7,5 +7,3 @@ SMTP_USERNAME=<>
 SMTP_PASSWORD=<>
 EMAIL_FROM=<>
 EMAIL_HOST=<>
-
-# Vue app folder ID (Optional)

--- a/devops/docker/docker-compose.ansible.yml
+++ b/devops/docker/docker-compose.ansible.yml
@@ -1,7 +1,7 @@
 version: "3.0"
 services:
   ansible:
-    image: kitware/esimmon-ansible
+    image: kitware/esimmon-ansible:0.1.0
     depends_on:
       - 'girder'
     build:

--- a/devops/docker/docker-compose.client.yml
+++ b/devops/docker/docker-compose.client.yml
@@ -7,7 +7,5 @@ services:
     build:
       context: ../../
       dockerfile: devops/docker/nginx/Dockerfile
-      args:
-        VUE_APP_FOLDER_ID: $VUE_APP_FOLDER_ID
     ports:
       - 9090:80

--- a/devops/docker/docker-compose.client.yml
+++ b/devops/docker/docker-compose.client.yml
@@ -1,7 +1,7 @@
 version: "3.0"
 services:
   client:
-    image: kitware/esimmon-client
+    image: kitware/esimmon-client:0.1.0
     depends_on:
       - girder
     build:

--- a/devops/docker/docker-compose.demo.yml
+++ b/devops/docker/docker-compose.demo.yml
@@ -1,7 +1,7 @@
 version: "3.0"
 services:
   demo:
-    image: kitware/esimmon-demo
+    image: kitware/esimmon-demo:0.1.0
     depends_on:
       - girder
     build:

--- a/devops/docker/docker-compose.fastapi.yml
+++ b/devops/docker/docker-compose.fastapi.yml
@@ -1,7 +1,7 @@
 version: "3.0"
 services:
   fastapi:
-    image: kitware/esimmon-fastapi
+    image: kitware/esimmon-fastapi:0.1.0
     ports:
       - 5000:5000
     env_file:

--- a/devops/docker/docker-compose.girder.yml
+++ b/devops/docker/docker-compose.girder.yml
@@ -8,7 +8,7 @@ services:
       - girder-db:/data/db
 
   girder:
-    image: kitware/esimmon-girder
+    image: kitware/esimmon-girder:0.1.0
     build:
       context: ../../
       dockerfile: devops/docker/girder/Dockerfile

--- a/devops/docker/docker-compose.watch-standalone.yml
+++ b/devops/docker/docker-compose.watch-standalone.yml
@@ -1,7 +1,7 @@
 version: "3.0"
 services:
   watch:
-    image: kitware/esimmon-cli:latest
+    image: kitware/esimmon-cli:0.1.0
     build:
       context: ../../
       dockerfile: devops/docker/ingest/Dockerfile

--- a/devops/docker/docker-compose.watch.yml
+++ b/devops/docker/docker-compose.watch.yml
@@ -1,7 +1,7 @@
 version: "3.0"
 services:
   watch:
-    image: kitware/esimmon-cli:latest
+    image: kitware/esimmon-cli:0.1.0
     build:
       context: ../../
       dockerfile: devops/docker/ingest/Dockerfile


### PR DESCRIPTION
- Remove checks for unused environment variables
- Fetch the default location starting folder id rather than hard-coding it. This means that we will no longer need different images for the NERSC and AWS deployments.
- Tag all of the containers with an initial `0.1.0` to match the current client version