### PR TITLE
Automatically generate movies

### DIFF
--- a/client/src/components/widgets/GirderDataBrowser/script.js
+++ b/client/src/components/widgets/GirderDataBrowser/script.js
@@ -66,9 +66,9 @@ export default {
       const { location, counts } = this;
       if (counts.nFolders || counts.nItems) {
         return this.fetchPaginatedFolderRows().then((rows) => {
-          // Filter out the internal 'timesteps' folder
+          // Filter out the internal 'timesteps'  and 'movies' folders
           return rows.filter((folder) => {
-            return folder.name !== "timesteps";
+            return folder.name !== "timesteps" && folder.name !== "movies";
           });
         });
       }

--- a/fastapi/app/api/api_v1/endpoints/movie.py
+++ b/fastapi/app/api/api_v1/endpoints/movie.py
@@ -19,6 +19,13 @@ from .variables import get_timestep_plot
 router = APIRouter()
 
 
+def _cleanup():
+    # Make sure we don't start collecting temp movie files as they can get quite large
+    path = f"{tempfile.gettempdir()}/esimmon*"
+    for ext in ["mp4", "mpg"]:
+        [os.remove(f) for f in glob.glob(f"{path}.{ext}")]
+
+
 async def _create_movie(
     id: str,
     format: str,
@@ -28,6 +35,9 @@ async def _create_movie(
     fps: Optional[str] = None,
     girder_token: str = Header(None),
 ):
+    # Clean up any old temp files that might be hanging around
+    _cleanup()
+
     selectedTimeSteps = (
         json.loads(unquote(selectedTimeSteps)) if selectedTimeSteps else timeSteps
     )

--- a/fastapi/app/api/api_v1/endpoints/movie.py
+++ b/fastapi/app/api/api_v1/endpoints/movie.py
@@ -19,28 +19,22 @@ from .variables import get_timestep_plot
 router = APIRouter()
 
 
-@router.get("/{id}/timesteps/movie", response_class=FileResponse)
-async def create_movie(
+async def _create_movie(
     id: str,
     format: str,
-    details: Optional[str] = None,
+    details: Optional[dict] = None,
+    timeSteps: Optional[str] = None,
     selectedTimeSteps: Optional[str] = None,
     fps: Optional[str] = None,
     girder_token: str = Header(None),
 ):
-    # Get all timesteps
-    gc = get_girder_client(girder_token)
-    item = gc.getItem(id)
-    timesteps = item["meta"]["timesteps"]
     selectedTimeSteps = (
-        json.loads(unquote(selectedTimeSteps)) if selectedTimeSteps else timesteps
+        json.loads(unquote(selectedTimeSteps)) if selectedTimeSteps else timeSteps
     )
-    # Check if there are additional settings to apply
-    details = json.loads(unquote(details)) if details else {}
-    framerate = fps if float(fps) else 10.0
-    with tempfile.TemporaryDirectory() as tmpdir:
+
+    with tempfile.TemporaryDirectory(prefix="esimmon") as tmpdir:
         for step in selectedTimeSteps:
-            if step in timesteps:
+            if step in timeSteps:
                 # call generate plot response and get plot
                 plot = await get_timestep_plot(id, step, girder_token, as_image=True)
                 image = await get_timestep_image_data(plot, "png", details)
@@ -50,7 +44,9 @@ async def create_movie(
                 )
                 im.save(f, "PNG")
         path_name = os.path.join(tmpdir, "*.png")
-        output_file = tempfile.NamedTemporaryFile(suffix=f".{format}", delete=False)
+        output_file = tempfile.NamedTemporaryFile(
+            prefix="esimmon", suffix=f".{format}", delete=False
+        )
         try:
             (
                 ffmpeg.input(path_name, pattern_type="glob", framerate=framerate)
@@ -60,4 +56,70 @@ async def create_movie(
             )
         except ffmpeg.Error as e:
             raise e
-        return FileResponse(path=output_file.name, media_type=f"video/{format}")
+
+    return output_file
+
+
+@router.get("/{id}/timesteps/movie", response_class=FileResponse)
+async def create_movie(
+    id: str,
+    format: str,
+    details: Optional[str] = None,
+    selectedTimeSteps: Optional[str] = None,
+    fps: Optional[str] = None,
+    girder_token: str = Header(None),
+):
+    # Get item information
+    gc = get_girder_client(girder_token)
+    item = gc.getItem(id)
+    movie_id = gc.getItem(id)["meta"].get("movieItemId", None)
+    files = list(gc.listFile(movie_id)) if movie_id else []
+
+    # Get all timesteps
+    timeSteps = item["meta"]["timesteps"]
+
+    # Check if there are additional settings to apply
+    details = json.loads(unquote(details)) if details else {}
+    no_deets = not any([v for k, v in details.items() if not v or k == "Axis"])
+    no_user_reqs = selectedTimeSteps is None and no_deets
+
+    if no_user_reqs and format in [f["exts"][0] for f in files]:
+        # The user is requesting the default movie, grab the pre-generated one
+        file_id = [f["_id"] for f in files if f["exts"][0] == format][0]
+        output_file = tempfile.NamedTemporaryFile(
+            prefix="esimmon", suffix=f".{format}", delete=False
+        )
+        gc.downloadFile(file_id, output_file.name)
+    else:
+        # This is a customized movie, generate it now
+        output_file = await _create_movie(
+            id, format, details, timeSteps, selectedTimeSteps, girder_token
+        )
+    return FileResponse(path=output_file.name, media_type=f"video/{format}")
+
+
+@router.put("/{id}/timesteps/movie")
+async def save_movie(
+    id: str,
+    format: str,
+    girder_token: str = Header(None),
+):
+    # Get item information
+    gc = get_girder_client(girder_token)
+    item = gc.getItem(id)
+    movie_id = gc.getItem(id)["meta"].get("movieItemId", None)
+    files = list(gc.listFile(movie_id)) if movie_id else []
+
+    # Get all timesteps
+    timeSteps = item["meta"]["timesteps"]
+
+    found_exts = [os.path.splitext(f["name"])[-1] for f in files]
+    if f".{format}" not in found_exts:
+        # We don't have the default movie(s) saved yet, generate it now
+        output_file = await _create_movie(id, format, {}, timeSteps, None, girder_token)
+        gc.uploadFileToItem(
+            itemId=movie_id,
+            filepath=output_file.name,
+            mimeType=f"video/{format}",
+            filename=f"{item['name']}.{format}",
+        )

--- a/fastapi/app/api/api_v1/endpoints/movie.py
+++ b/fastapi/app/api/api_v1/endpoints/movie.py
@@ -1,3 +1,4 @@
+import glob
 import io
 import json
 import os


### PR DESCRIPTION
Now when a run is being ingested we:

1. Create a new folder within the run for all movies
 1. This follows the [same directory structure](https://github.com/bnmajor/adios-dashboard/blob/f40da9c2f1afd742ef3970fe2aca481d93733263/ingest/esimmon/cli/watch/__init__.py#L461-L465) as the run. We then [store the id](https://github.com/bnmajor/adios-dashboard/blob/f40da9c2f1afd742ef3970fe2aca481d93733263/ingest/esimmon/cli/watch/__init__.py#L467-L471) for the original item in the metadata on the movie item and vice versa (this saves search time for the client side).
3. Watch for the run to be [marked complete](https://github.com/bnmajor/adios-dashboard/blob/f40da9c2f1afd742ef3970fe2aca481d93733263/ingest/esimmon/cli/watch/__init__.py#L704)
4. Wait for any final images (`bp` files) to be [ingested and then begin creating movies](https://github.com/bnmajor/adios-dashboard/blob/f40da9c2f1afd742ef3970fe2aca481d93733263/ingest/esimmon/cli/watch/__init__.py#L706-L714) for each plot in the run
5. [Generate movies](https://github.com/bnmajor/adios-dashboard/blob/f40da9c2f1afd742ef3970fe2aca481d93733263/ingest/esimmon/cli/watch/__init__.py#L249-L257) for each plot going folder by folder in the movies directory
6. If this movie has already been generated we [download that instead](https://github.com/bnmajor/adios-dashboard/blob/f40da9c2f1afd742ef3970fe2aca481d93733263/fastapi/app/api/api_v1/endpoints/movie.py#L105-L110) of re-generating the movie (applies only when all time steps are selected).