### PR TITLE
Bump vtkjs

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@girder/components": "^3.2.0",
-    "@kitware/vtk.js": "^27.4.2",
+    "@kitware/vtk.js": "^25.15.1",
     "@msgpack/msgpack": "^2.7.2",
     "axios": "^0.21.2",
     "core-js": "^3.8.3",

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@girder/components": "^3.2.0",
-    "@kitware/vtk.js": "^22.6.1",
+    "@kitware/vtk.js": "^27.4.2",
     "@msgpack/msgpack": "^2.7.2",
     "axios": "^0.21.2",
     "core-js": "^3.8.3",

--- a/client/src/components/widgets/RenderWindow/script.js
+++ b/client/src/components/widgets/RenderWindow/script.js
@@ -51,9 +51,7 @@ export default {
     resetZoom(e) {
       if (!this.syncZoom && !this.selectTimeStep) {
         document.elementsFromPoint(e.clientX, e.clientY).forEach((elem) => {
-          console.log(elem.classList);
           if (elem.classList[0] === "plot") {
-            console.log(elem.__vue__);
             elem.__vue__.resetZoom();
           }
         });

--- a/client/src/components/widgets/RenderWindow/script.js
+++ b/client/src/components/widgets/RenderWindow/script.js
@@ -59,6 +59,13 @@ export default {
         });
       }
     },
+    contextMenu(e) {
+      document.elementsFromPoint(e.clientX, e.clientY).forEach((elem) => {
+        if (elem.classList[0] === "v-card") {
+          elem.__vue__.$options.parent.requestContextMenu(e);
+        }
+      });
+    },
   },
 
   mounted() {
@@ -90,6 +97,7 @@ export default {
     // children. Instead we need to listen and handle them here.y
     this.container.addEventListener("dblclick", this.resetAllZoom);
     this.container.addEventListener("dblclick", this.resetZoom);
+    this.container.addEventListener("contextmenu", this.contextMenu);
     window.addEventListener("resize", this.resize);
     this.resize();
     window.requestAnimationFrame(this.animate);

--- a/client/src/components/widgets/RenderWindow/script.js
+++ b/client/src/components/widgets/RenderWindow/script.js
@@ -41,8 +41,20 @@ export default {
       if (this.syncZoom && !this.selectTimeStep) {
         const allRenderers = this.$root.$children[0].$refs.plots;
         allRenderers.forEach((plotCell) => {
-          if (plotCell.renderer) {
-            plotCell.resetZoom();
+          const { col, row } = plotCell.$options.propsData;
+          if (plotCell.$refs[`${row}-${col}`]?.renderer) {
+            plotCell.$refs[`${row}-${col}`].resetZoom();
+          }
+        });
+      }
+    },
+    resetZoom(e) {
+      if (!this.syncZoom && !this.selectTimeStep) {
+        document.elementsFromPoint(e.clientX, e.clientY).forEach((elem) => {
+          console.log(elem.classList);
+          if (elem.classList[0] === "plot") {
+            console.log(elem.__vue__);
+            elem.__vue__.resetZoom();
           }
         });
       }
@@ -74,7 +86,10 @@ export default {
     this.interactor.bindEvents(this.container);
     this.interactor.disable();
 
-    window.addEventListener("dblclick", this.resetAllZoom);
+    // After vtk.js 24.0.0 these events no longer propogate down to the correct
+    // children. Instead we need to listen and handle them here.y
+    this.container.addEventListener("dblclick", this.resetAllZoom);
+    this.container.addEventListener("dblclick", this.resetZoom);
     window.addEventListener("resize", this.resize);
     this.resize();
     window.requestAnimationFrame(this.animate);

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -1,7 +1,6 @@
 import { isNil, isEqual } from "lodash";
 import { mapGetters, mapMutations } from "vuex";
 import {
-  setAxesStyling,
   scalarBarAutoLayout,
   customGenerateTicks,
 } from "../../../utils/vtkPlotStyling";
@@ -14,13 +13,13 @@ import "@kitware/vtk.js/Rendering/Profiles/Geometry";
 import vtkActor from "@kitware/vtk.js/Rendering/Core/Actor";
 import vtkColorMaps from "@kitware/vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps";
 import vtkColorTransferFunction from "@kitware/vtk.js/Rendering/Core/ColorTransferFunction";
-import vtkCubeAxesActor from "@kitware/vtk.js/Rendering/Core/CubeAxesActor";
 import vtkDataArray from "@kitware/vtk.js/Common/Core/DataArray";
 import vtkMapper from "@kitware/vtk.js/Rendering/Core/Mapper";
 import vtkPointPicker from "@kitware/vtk.js/Rendering/Core/PointPicker";
 import vtkPolyData from "@kitware/vtk.js/Common/DataModel/PolyData";
 import vtkRenderer from "@kitware/vtk.js/Rendering/Core/Renderer";
 import vtkScalarBarActor from "@kitware/vtk.js/Rendering/Core/ScalarBarActor";
+import vtkCustomCubeAxesActor from "../../../utils/vtkCustomCubeAxesActor";
 
 const X_AXES_LABEL_BOUNDS_ADJUSTMENT = 0.3;
 const Y_AXES_LABEL_BOUNDS_ADJUSTMENT = 0.001;
@@ -249,11 +248,11 @@ export default {
       this.camera.setParallelProjection(true);
 
       // Create axis
-      this.axes = vtkCubeAxesActor.newInstance();
+      this.axes = vtkCustomCubeAxesActor.newInstance();
       this.axes.setCamera(this.camera);
       this.axes.setAxisLabels(data.xLabel, data.yLabel, "");
-      this.axes.getGridActor().getProperty().setColor("black");
-      this.axes.getGridActor().getProperty().setLineWidth(0.1);
+      this.axes.getProperty().setColor("black");
+      this.axes.getProperty().setLineWidth(0.1);
       if (this.plotType === PlotType.ColorMap) {
         this.axes.setGridLines(false);
       }
@@ -351,16 +350,9 @@ export default {
       // TODO: Remove this when we have more functionality in VTK charts
       // Use the original data from the mesh rather than the potentially scaled
       // actor data
-      this.axes.setDataBounds(this.mesh.getBounds());
-      this.axes.setScaleFrom(this.actor.getScale());
+      this.axes.setDataBounds(this.actor.getBounds());
       const [scale] = this.actor.getScale();
-      const { faces, edges, ticks, labels } = setAxesStyling(this.axes, scale);
-      this.axes.updateTextData(faces, edges, ticks, labels);
-      if (scale !== 1) {
-        // TODO: Remove this when we have more functionality in VTK charts
-        // Remove the axis border since scaling does not shrink the bounding box
-        this.axes.getGridActor().getMapper().getInputData().getLines().delete();
-      }
+      this.axes.setTicksScale(scale);
 
       // TODO: Remove this when we have more functionality in VTK charts
       // Hack to adjust the bounds to include the x label

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -610,11 +610,6 @@ export default {
   mounted() {
     this.$el.addEventListener("mouseenter", this.enterCurrentRenderer);
     this.$el.addEventListener("mouseleave", this.exitCurrentRenderer);
-    this.$el.addEventListener("dblclick", () => {
-      if (this.renderer) {
-        this.resetZoom();
-      }
-    });
   },
 
   beforeDestroy() {

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -535,8 +535,8 @@ export default {
         const pos = callData.position;
         const point = [pos.x, pos.y, 0.0];
         picker.pick(point, this.renderer);
-        if (picker.getActors().length !== 0 && this.startPoints) {
-          const pickedPoints = picker.getPickedPositions();
+        const pickedPoints = picker.getPickedPositions();
+        if (pickedPoints.length && this.startPoints) {
           if (isEqual(pickedPoints[0], this.startPoints)) {
             // This was just a single click
             return;

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -3,6 +3,7 @@ import { mapGetters, mapMutations } from "vuex";
 import {
   setAxesStyling,
   scalarBarAutoLayout,
+  customGenerateTicks,
 } from "../../../utils/vtkPlotStyling";
 import { PlotType } from "../../../utils/constants";
 import Annotations from "../Annotations";
@@ -260,6 +261,7 @@ export default {
 
       // Build color bar
       this.scalarBar = vtkScalarBarActor.newInstance();
+      this.scalarBar.setGenerateTicks(customGenerateTicks(6));
       this.scalarBar.setScalarsToColors(lut);
       this.scalarBar.setAxisLabel(data.colorLabel);
       this.scalarBar.setAxisTextStyle({ fontColor: "black" });

--- a/client/src/utils/vtkCustomCubeAxesActor.js
+++ b/client/src/utils/vtkCustomCubeAxesActor.js
@@ -1,0 +1,81 @@
+import macro from "@kitware/vtk.js/macros";
+import vtkCubeAxesActor from "@kitware/vtk.js/Rendering/Core/CubeAxesActor";
+import * as d3 from "d3-scale";
+
+const facesToDraw = [false, false, false, false, false, true];
+const edgesToDraw = [0, 0, 0, 0, 1, 2, 2, 1, 0, 0, 0, 0];
+
+function vtkCustomCubeAxesActor(publicAPI, model) {
+  model.classHierarchy.push("vtkCustomCubeAxesActor");
+
+  publicAPI.update = () => {
+    if (!model.camera) {
+      return;
+    }
+
+    // compute what faces to draw
+    const facesChanged = publicAPI.computeFacesToDraw();
+    // const facesToDraw = model.lastFacesToDraw;
+
+    // have the bounds changed?
+    let boundsChanged = false;
+    for (let i = 0; i < 6; i++) {
+      if (model.dataBounds[i] !== model.lastTickBounds[i]) {
+        boundsChanged = true;
+        model.lastTickBounds[i] = model.dataBounds[i];
+      }
+    }
+
+    // did something significant change? If so rebuild a lot of things
+    if (facesChanged || boundsChanged || model.forceUpdate) {
+      // compute tick marks for axes
+      const ticks = [];
+      const tickStrings = [];
+      for (let i = 0; i < 2; i++) {
+        // We only want x and y values for 2D plots, hence i < 2
+        const scale = d3
+          .scaleLinear()
+          .domain([model.dataBounds[i * 2], model.dataBounds[i * 2 + 1]]);
+        ticks[i] = scale.ticks(model.ticksNo);
+        const format = scale.tickFormat(model.ticksNo);
+        tickStrings[i] = ticks[i].map((t) => t / model.ticksScale).map(format);
+      }
+
+      // Hardcode the z values that we're not using
+      tickStrings[2] = ["0"];
+      ticks[2] = [0];
+
+      // update gridlines / edge lines
+      publicAPI.updatePolyData(facesToDraw, edgesToDraw, ticks);
+
+      // compute label world coords and text
+      publicAPI.updateTextData(facesToDraw, edgesToDraw, ticks, tickStrings);
+
+      // rebuild the texture only when force or changed bounds, face
+      // visibility changes do to change the atlas
+      if (boundsChanged || model.forceUpdate) {
+        publicAPI.updateTextureAtlas(tickStrings);
+      }
+    }
+
+    model.forceUpdate = false;
+  };
+}
+
+const DEFAULT_VALUES = {
+  ticksNo: 4,
+  ticksScale: 1,
+};
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  vtkCubeAxesActor.extend(publicAPI, model, initialValues);
+  macro.setGet(publicAPI, model, ["ticksNo"]);
+  macro.setGet(publicAPI, model, ["ticksScale"]);
+  vtkCustomCubeAxesActor(publicAPI, model);
+}
+
+export const newInstance = macro.newInstance(extend, "vtkCustomCubeAxesActor");
+
+export default { newInstance, extend };

--- a/client/src/utils/vtkPlotStyling.js
+++ b/client/src/utils/vtkPlotStyling.js
@@ -1,3 +1,6 @@
+import { scaleLinear } from "d3-scale";
+import { format } from "d3-format";
+
 export function setAxesStyling(axes, scale) {
   const tickCounts = axes.getTickCounts();
   let textValues = axes.getTextValues();
@@ -90,5 +93,24 @@ export function scalarBarAutoLayout(model) {
 
     // recomute bar segments based on positioning
     helper.recomputeBarSegments(textSizes);
+  };
+}
+
+// Copied from the example at
+// https://github.com/Kitware/vtk-js/blob/1400faebd8899265ad3ffb5f165ec624ce3389fe/Sources/Rendering/Core/ScalarBarActor/example/index.js#L44-L65
+// Modified to use scientific notation
+export function customGenerateTicks(numberOfTicks) {
+  return (helper) => {
+    const lastTickBounds = helper.getLastTickBounds();
+    // compute tick marks for axes
+    const scale = scaleLinear()
+      .domain([0.0, 1.0])
+      .range([lastTickBounds[0], lastTickBounds[1]]);
+    const samples = scale.ticks(numberOfTicks);
+    const ticks = samples.map((tick) => scale(tick));
+    const tickFormat = format(".2e");
+    const tickStrings = ticks.map(tickFormat);
+    helper.setTicks(ticks);
+    helper.setTickStrings(tickStrings);
   };
 }

--- a/client/src/utils/vtkPlotStyling.js
+++ b/client/src/utils/vtkPlotStyling.js
@@ -1,34 +1,6 @@
 import { scaleLinear } from "d3-scale";
 import { format } from "d3-format";
 
-export function setAxesStyling(axes, scale) {
-  const tickCounts = axes.getTickCounts();
-  let textValues = axes.getTextValues();
-  const labels = new Array(3);
-  const ticks = new Array(3);
-  let start = 0;
-  for (var i = 0; i < 2; i++) {
-    let factor = i === 0 ? scale : 1;
-    // We only want x and y values for 2D plots, hence i < 2
-    let numLabels = tickCounts[i] + 1;
-    labels[i] = textValues.slice(start + 1, start + numLabels);
-    ticks[i] = textValues.slice(start + 1, (start += numLabels)).map((v) => {
-      if (v.startsWith("−")) {
-        // The negative values are stored with an em dash rather than a dash
-        return parseFloat(v.slice(1)) * factor * -1;
-      }
-      return parseFloat(v) * factor;
-    });
-  }
-  // Hardcode the z values that we're not using
-  labels[2] = ["0"];
-  ticks[2] = [0];
-  const faces = [false, false, false, false, false, true];
-  // Only place labels on the left and bottom of the axes
-  const edges = [0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0];
-  return { faces, edges, ticks, labels };
-}
-
 /*
 This function is a modified version of the defaultAutoLayout found at 
 https://github.com/Kitware/vtk-js/blob/master/Sources/Rendering/Core/ScalarBarActor/index.js#L66-L146.

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -986,10 +986,10 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
-  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
+"@babel/runtime@7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1414,10 +1414,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@kitware/vtk.js@^22.6.1":
-  version "22.6.2"
-  resolved "https://registry.yarnpkg.com/@kitware/vtk.js/-/vtk.js-22.6.2.tgz#3bc2902c191a9e4224493a5101050bbff90eec07"
-  integrity sha512-w2nOL1LGOOY8zVyKQ/ZhiBXyaoF73EwowvYsIdMJsdqUy7B9Vx1lbl8O5OyqA+Dp7ck7cOsB+PKK3I1P7PFFAA==
+"@kitware/vtk.js@^25.15.1":
+  version "25.15.2"
+  resolved "https://registry.yarnpkg.com/@kitware/vtk.js/-/vtk.js-25.15.2.tgz#314dbb7c25edfd44b134185be6493a6f775d8a88"
+  integrity sha512-bekuiKfB2O9IRJBGXScnWDqA1nT9yAoJJ9t/GTritdrhx4B9kwtcj8sc4MTX000UN7sVruyHoM/NF5qeKvx+fQ==
   dependencies:
     "@babel/runtime" "7.17.9"
     commander "9.2.0"
@@ -7699,7 +7699,7 @@ read-pkg@^5.1.1, read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@^2.0.1, readable-stream@~2.3.6:
+readable-stream@^2.0.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1419,19 +1419,19 @@
   resolved "https://registry.yarnpkg.com/@kitware/vtk.js/-/vtk.js-22.6.2.tgz#3bc2902c191a9e4224493a5101050bbff90eec07"
   integrity sha512-w2nOL1LGOOY8zVyKQ/ZhiBXyaoF73EwowvYsIdMJsdqUy7B9Vx1lbl8O5OyqA+Dp7ck7cOsB+PKK3I1P7PFFAA==
   dependencies:
-    "@babel/runtime" "7.16.7"
-    commander "8.3.0"
+    "@babel/runtime" "7.17.9"
+    commander "9.2.0"
     d3-scale "4.0.2"
+    fast-deep-equal "^3.1.3"
+    fflate "0.7.3"
     gl-matrix "3.4.3"
-    globalthis "1.0.2"
-    jszip "3.7.1"
-    pako "2.0.4"
+    globalthis "1.0.3"
     seedrandom "3.0.5"
     shader-loader "1.3.1"
     shelljs "0.8.5"
-    spark-md5 "^3.0.2"
+    spark-md5 "3.0.2"
     stream-browserify "3.0.0"
-    webworker-promise "0.4.4"
+    webworker-promise "0.5.0"
     worker-loader "3.0.8"
     xmlbuilder2 "3.0.2"
 
@@ -3306,10 +3306,10 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@8.3.0, commander@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
-  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+commander@9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.2.0.tgz#6e21014b2ed90d8b7c9647230d8b7a94a4a419a9"
+  integrity sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==
 
 commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
@@ -3320,6 +3320,11 @@ commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
+commander@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -4495,6 +4500,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fflate@0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.7.3.tgz#288b034ff0e9c380eaa2feff48c787b8371b7fa5"
+  integrity sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw==
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -4832,10 +4842,10 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globalthis@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.2.tgz#2a235d34f4d8036219f7e34929b5de9e18166b8b"
-  integrity sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==
+globalthis@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.3.tgz#5852882a52b80dc301b0660273e1ed082f0b6ccf"
+  integrity sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==
   dependencies:
     define-properties "^1.1.3"
 
@@ -5169,11 +5179,6 @@ ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
-
-immediate@~3.0.5:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
-  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
 
 import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -6180,16 +6185,6 @@ jsprim@^1.2.2:
     json-schema "0.4.0"
     verror "1.10.0"
 
-jszip@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.7.1.tgz#bd63401221c15625a1228c556ca8a68da6fda3d9"
-  integrity sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==
-  dependencies:
-    lie "~3.3.0"
-    pako "~1.0.2"
-    readable-stream "~2.3.6"
-    set-immediate-shim "~1.0.1"
-
 kind-of@^3.0.2, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
@@ -6240,13 +6235,6 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
-
-lie@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
-  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
-  dependencies:
-    immediate "~3.0.5"
 
 lilconfig@^2.0.3:
   version "2.1.0"
@@ -7089,16 +7077,6 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
-
-pako@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.4.tgz#6cebc4bbb0b6c73b0d5b8d7e8476e2b2fbea576d"
-  integrity sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==
-
-pako@~1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 param-case@^3.0.4:
   version "3.0.4"
@@ -8139,11 +8117,6 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
-set-immediate-shim@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
-  integrity sha512-Li5AOqrZWCVA2n5kryzEmqai6bKSIvpz5oUJHPVj6+dsbD3X1ixtsY5tEnsaNpH3pFAHmG8eIHUrtEtohrg+UQ==
-
 set-value@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
@@ -8346,7 +8319,7 @@ source-map@^0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
-spark-md5@^3.0.2:
+spark-md5@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
@@ -9399,10 +9372,10 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
-webworker-promise@0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/webworker-promise/-/webworker-promise-0.4.4.tgz#722b0ccade10ccb4e810325e5ebff00eb0e1b1be"
-  integrity sha512-NfdSlaWqd+0iSrQudB0N0MELfJ9TVTlynhXMpi06piuZhyc9Yy7Hz6BFu2HUkvIb9lCS0pFW42ptd/JnXVnptg==
+webworker-promise@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/webworker-promise/-/webworker-promise-0.5.0.tgz#eb1aa89f26ca6a49765f332668644d74c2c8e320"
+  integrity sha512-14iR79jHAV7ozwvbfif+3wCaApT3I1g8Lo0rJZrwAu6wxZGx/08Y8KXz6as6ZLNUEEufeiEBBYrqyDBClXOsEw==
 
 whatwg-encoding@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Bump `vtk.js` version `22.6.1` -> `25.15.1`.

- There is a bug with the `vtkCubeAxesActor` in `v26.0.0` where axes labels are not always rendered correctly or at all. Until this can be investigated further and the issue pinned down we will pin to `v25.15.1` (the last available release where the bug is not seen).
- In `v24.0.0` some breaking changes were introduced that seem to affect the way events are captured and passed along. This PR adds new event handlers to catch double-click to zoom out as well as right-click for the context menu.
- We are now using scientific notation for the scalar bars so that text does not overlap the plots.