### PR TITLE
Bugs

### DIFF
--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -213,8 +213,7 @@ export default {
           cell.loadTemplateGallery(item);
         }
       });
-      this.setCurrentTimeStep(this.viewTimeStep);
-      this.loadingFromSaved(false);
+      this.setCurrentTimeStep(this.minTimeStep);
     },
 
     resetView() {
@@ -405,6 +404,13 @@ export default {
 
       // Setup polling to autosave view
       this.autosave();
+    },
+
+    numReady(ready) {
+      if ((ready === this.gridSize) & this.loadedFromSaved) {
+        this.loadingFromSaved(false);
+        this.setCurrentTimeStep(this.viewTimeStep);
+      }
     },
   },
 };

--- a/client/src/components/widgets/PlotlyPlot/script.js
+++ b/client/src/components/widgets/PlotlyPlot/script.js
@@ -325,8 +325,8 @@ export default {
           modeBarButtonsToRemove: ["toImage"],
         });
         if (!this.eventHandlersSet) this.setEventHandlers();
+        this.updateNumReady(this.numReady + 1);
       }
-      this.updateNumReady(this.numReady + 1);
     },
     setEventHandlers() {
       this.$refs.plotly.on("plotly_relayout", (eventdata) => {

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -142,6 +142,10 @@ export default {
       updateNumReady: "VIEW_NUM_READY_SET",
     }),
     setAvailableTimeSteps: function (steps) {
+      if (!this.itemId) {
+        return;
+      }
+
       this.$store.dispatch(
         `${this.itemId}/PLOT_AVAILABLE_TIME_STEPS_CHANGED`,
         steps,
@@ -388,6 +392,7 @@ export default {
 
       // Update this plot
       this.$refs[`${this.row}-${this.col}`].react();
+      this.updateNumReady(this.numReady + 1);
     },
     /**
      * Display the the current timestep, if the current timestep is not valid
@@ -416,6 +421,7 @@ export default {
     },
     clearGallery() {
       this.updateVisiblePlots({ newId: null, oldId: this.itemId });
+      this.setAvailableTimeSteps([]);
       this.itemId = "";
       this.setInitialLoad(true);
     },
@@ -457,5 +463,6 @@ export default {
 
   beforeDestroyed() {
     this.$store.unregisterModule(this.itemId);
+    this.updateVisiblePlots({ newId: null, oldId: this.itemId });
   },
 };

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -458,11 +458,11 @@ export default {
   },
 
   destroyed() {
+    this.updateVisiblePlots({ newId: null, oldId: this.itemId });
     this.setGridSize(this.gridSize - 1);
   },
 
   beforeDestroyed() {
     this.$store.unregisterModule(this.itemId);
-    this.updateVisiblePlots({ newId: null, oldId: this.itemId });
   },
 };

--- a/client/src/components/widgets/SaveDialog/script.js
+++ b/client/src/components/widgets/SaveDialog/script.js
@@ -56,6 +56,7 @@ export default {
       updateView: "VIEWS_UPDATE_EXISTING",
     }),
     ...mapMutations({
+      setLastLoaded: "VIEWS_LAST_LOADED_ID_SET",
       setPublic: "VIEWS_PUBLIC_SET",
       setShowSaveDialog: "UI_SHOW_SAVE_DIALOG_SET",
     }),
@@ -66,6 +67,7 @@ export default {
       if (newView) {
         this.createView(this.newViewName);
       } else {
+        this.setLastLoaded(this.viewInfo[this.newViewName]);
         this.updateView(this.newViewName);
       }
       this.setShowSaveDialog(false);

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -176,8 +176,8 @@ export default {
           this.updateRenderer(nextImage.data);
           this.lastLoadedTimeStep = nextImage.timestep;
         }
+        this.updateNumReady(this.numReady + 1);
       }
-      this.updateNumReady(this.numReady + 1);
     },
     updateViewPort() {
       this.$nextTick(() => {

--- a/client/src/store/plot.js
+++ b/client/src/store/plot.js
@@ -94,21 +94,23 @@ export default {
     PLOT_AVAILABLE_TIME_STEPS_CHANGED({ commit, rootGetters }, timeSteps) {
       commit("PLOT_AVAILABLE_TIME_STEPS_SET", timeSteps);
 
-      let timeStep = rootGetters.VIEW_TIME_STEP;
-      let minTimeStep = rootGetters.VIEW_MIN_TIME_STEP;
-      let maxTimeStep = rootGetters.VIEW_MAX_TIME_STEP;
-      let tsMin = Math.min(...timeSteps);
-      let tsMax = Math.max(...timeSteps);
+      let newMin = Infinity;
+      let newMax = -Infinity;
+      rootGetters.VIEW_SELECTIONS.forEach((id) => {
+        let steps = rootGetters[`${id}/PLOT_AVAILABLE_TIME_STEPS`] || [];
+        let tsMin = Math.min(...steps);
+        let tsMax = Math.max(...steps);
 
-      let newMin =
-        maxTimeStep < minTimeStep ? tsMin : Math.min(minTimeStep, tsMin);
-      let newMax =
-        maxTimeStep < minTimeStep ? tsMax : Math.max(maxTimeStep, tsMax);
-      let newCurr = Math.max(Math.min(timeStep, newMax), newMin);
-
+        newMin = Math.min(newMin, tsMin);
+        newMax = Math.max(newMax, tsMax);
+      });
       commit("VIEW_MIN_TIME_STEP_SET", newMin, { root: true });
       commit("VIEW_MAX_TIME_STEP_SET", newMax, { root: true });
-      commit("VIEW_TIME_STEP_SET", newCurr, { root: true });
+      if (!rootGetters.VIEW_LOADING_FROM_SAVED) {
+        let timeStep = rootGetters.VIEW_TIME_STEP;
+        let newCurr = Math.max(Math.min(timeStep, newMax), newMin);
+        commit("VIEW_TIME_STEP_SET", newCurr, { root: true });
+      }
     },
   },
 };

--- a/client/src/utils/plotFetcher.ts
+++ b/client/src/utils/plotFetcher.ts
@@ -221,6 +221,16 @@ export class PlotFetcher {
     return task.result;
   }
 
+  cancelAllTasks() {
+    if (!this.initialized) {
+      throw new Error(`The PlotFetcher for item ${this.itemId} has not been initialized.`);
+    }
+
+    Object.entries(this.tasks).forEach(([, task]) => {
+      registry.cancelTask(task.id)
+    });
+  }
+
   private preFetchPlots(timestep: number) {
     let idx = this.availableTimesteps.indexOf(timestep);
 

--- a/devops/docker/fastapi/Dockerfile
+++ b/devops/docker/fastapi/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 RUN conda install -c \
   conda-forge \
   python=3.9 \
-  cmake \
+  cmake=3.26.4 \
   ninja \
   mako
 


### PR DESCRIPTION
Clean up a handful of bugs:

- Loading one template after another would sometimes fail to render all plots correctly. This was caused by pre-fetched data resolving for the previous plot after the new plot was loaded. Cancel pending requests when a new plot is loaded.
- Make sure the the min/max time steps are always updated any time a plot is added, changed or removed. Fixes issues with the slider being positioned incorrectly as well.
- Make sure that the highlighted variables are updated when rows/columns are removed.