### PR TITLE
Global range

### DIFF
--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -172,6 +172,7 @@ export default {
     },
 
     applyView() {
+      this.updateNumReady(0);
       this.$refs.plots.forEach((cell) => {
         const { row, col } = cell;
         const item = this.items[`${row}::${col}`];

--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -32,10 +32,7 @@ export default {
       dataLoaded: false,
       forgotPasswordUrl: "/#?dialog=resetpassword",
       runId: null,
-      range: "",
-      pos: [],
       parameter: "",
-      cancel: false,
       showMenu: false,
       paramIsJson: false,
     };
@@ -82,37 +79,6 @@ export default {
         this.setCurrentTimeStep(this.currentTimeStep - 1);
       }
       this.setPaused(should_pause);
-    },
-
-    hoverOut() {
-      this.range = "";
-      this.cancel = true;
-    },
-
-    hoverIn: _.debounce(function (event) {
-      if (this.showMenu) return;
-
-      const node = event.target;
-      const parent = node ? node.parentNode : null;
-      if (
-        (parent && parent.classList.value.includes("pl-3")) ||
-        (node.classList.value.includes("pl-3") &&
-          node.textContent != parent.textContent)
-      ) {
-        this.parameter = node.textContent.trim();
-        this.cancel = false;
-        // this.getRangeData(event);
-      }
-    }, 100),
-
-    updateRange(yVals, event) {
-      this.pos = event ? [event.clientX, event.clientY] : this.pos;
-      this.range =
-        "[" +
-        Math.min(...yVals).toExponential(3) +
-        ", " +
-        Math.max(...yVals).toExponential(3) +
-        "]";
     },
 
     updateTimeStep(val) {

--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -237,7 +237,7 @@ export default {
       viewTimeStep: "VIEW_SAVED_TIME_STEP",
       numReady: "VIEW_NUM_READY",
       loadedFromSaved: "VIEW_LOADING_FROM_SAVED",
-      lastSaved: "VIEW_LAST_SAVED",
+      lastSaved: "VIEWS_LAST_SAVED",
       creator: "VIEWS_CREATOR",
       gridSize: "VIEWS_GRID_SIZE",
       items: "VIEWS_ITEMS",

--- a/client/src/components/core/App/template.html
+++ b/client/src/components/core/App/template.html
@@ -68,7 +68,8 @@
                   :max="maxTimeStep"
                   :disabled="!dataLoaded"
                   :value="currentTimeStep"
-                  @change="(e) => {updateTimeStep(e.target.value)}"
+                  @change="updateTimeStep"
+                  :style="{minWidth: '110px'}"
                 >
                   <template>
                     <v-icon

--- a/client/src/components/core/App/template.html
+++ b/client/src/components/core/App/template.html
@@ -29,7 +29,7 @@
             :fluid="true"
             class="playback-controls"
           >
-            <v-row class="ma-0 pa-0" :style="{height: '25px'}">
+            <v-row class="mx-0 my-1 pa-0" :style="{height: '25px'}">
               <v-slider
                 dense
                 hide-details
@@ -57,7 +57,7 @@
                 </template>
               </v-slider>
             </v-row>
-            <v-row class="ma-0 pa-0" :style="{height: '25px'}">
+            <v-row class="mx-0 my-1 pa-0" :style="{height: '25px'}">
               <v-col :sm="4">
                 <v-text-field
                   dense
@@ -91,7 +91,7 @@
                 </v-text-field>
               </v-col>
             </v-row>
-            <v-row class="ma-0 pa-0" :style="{height: '25px'}">
+            <v-row class="mx-0 mt-4 mb-0 pa-0" :style="{height: '25px'}">
               <v-col :sm="6">
                 <v-row class="align-center justify-space-evenly">
                   <v-icon v-on:click="removeRow()" :disabled="numrows < 2">
@@ -115,7 +115,7 @@
                 </v-row>
               </v-col>
             </v-row>
-            <v-row class="ma-0 pa-0" :style="{height: '25px'}">
+            <v-row class="mx-0 my-1 pa-0" :style="{height: '25px'}">
               <v-col class="align-center">
                 <v-tooltip top>
                   <template v-slot:activator="{on, attrs}">
@@ -134,7 +134,8 @@
             </v-row>
             <v-row
               v-show="lastSaved"
-              :style="{height: '5px', alignContent: 'start'}"
+              class="mx-0 my-1 pa-0"
+              :style="{height: '25px'}"
             >
               <span v-bind:style="{fontSize: 'small', opacity: '0.5'}">
                 View Autosaved: {{ new Date(lastSaved).toLocaleTimeString() }}

--- a/client/src/components/core/App/template.html
+++ b/client/src/components/core/App/template.html
@@ -29,7 +29,7 @@
             :fluid="true"
             class="playback-controls"
           >
-            <v-row class="mx-0 my-1 pa-0" :style="{height: '25px'}">
+            <v-row class="mx-0 my-1 pa-0" style="height: 25px">
               <v-slider
                 dense
                 hide-details
@@ -57,7 +57,7 @@
                 </template>
               </v-slider>
             </v-row>
-            <v-row class="mx-0 my-1 pa-0" :style="{height: '25px'}">
+            <v-row class="mx-0 my-1 pa-0" style="height: 25px">
               <v-col :sm="4">
                 <v-text-field
                   dense
@@ -69,7 +69,7 @@
                   :disabled="!dataLoaded"
                   :value="currentTimeStep"
                   @change="updateTimeStep"
-                  :style="{minWidth: '110px'}"
+                  style="min-width: 110px"
                 >
                   <template>
                     <v-icon
@@ -92,7 +92,7 @@
                 </v-text-field>
               </v-col>
             </v-row>
-            <v-row class="mx-0 mt-4 mb-0 pa-0" :style="{height: '25px'}">
+            <v-row class="mx-0 mt-4 mb-0 pa-0" style="height: 25px">
               <v-col :sm="6">
                 <v-row class="align-center justify-space-evenly">
                   <v-icon v-on:click="removeRow()" :disabled="numrows < 2">
@@ -116,7 +116,7 @@
                 </v-row>
               </v-col>
             </v-row>
-            <v-row class="mx-0 my-1 pa-0" :style="{height: '25px'}">
+            <v-row class="mx-0 my-1 pa-0" style="height: 25px">
               <v-col class="align-center">
                 <v-tooltip top>
                   <template v-slot:activator="{on, attrs}">
@@ -136,7 +136,7 @@
             <v-row
               v-show="lastSaved"
               class="mx-0 my-1 pa-0"
-              :style="{height: '25px'}"
+              style="height: 25px"
             >
               <span v-bind:style="{fontSize: 'small', opacity: '0.5'}">
                 View Autosaved: {{ new Date(lastSaved).toLocaleTimeString() }}

--- a/client/src/components/core/App/template.html
+++ b/client/src/components/core/App/template.html
@@ -14,23 +14,9 @@
         <v-col v-bind:style="{padding: '0 10px'}">
           <!-- Girder data table browser. -->
           <div class="girder-placeholder" v-if="!location" />
-          <div>
-            <v-tooltip
-              right
-              light
-              v-if="range"
-              :value="range"
-              :position-x="pos[0]"
-              :position-y="pos[1]"
-            >
-              <span v-if="range">{{range}}</span>
-            </v-tooltip>
-          </div>
           <girder-file-manager
             ref="girderFileManager"
             v-if="location && !showSettings"
-            v-on:mouseover.native="hoverIn($event)"
-            v-on:mouseout.native="hoverOut"
             :location.sync="location"
             :selectable="false"
             :drag-enabled="true"
@@ -42,7 +28,6 @@
             v-if="!showSettings"
             :fluid="true"
             class="playback-controls"
-            v-on:mouseover="hoverOut"
           >
             <v-row class="ma-0 pa-0" :style="{height: '25px'}">
               <v-slider
@@ -160,13 +145,7 @@
       </v-row>
     </pane>
     <!-- Scientific data on the right. -->
-    <pane
-      id="mainContent"
-      min-size="50"
-      :size="85"
-      class="main-content"
-      v-on:mouseover.native="hoverOut"
-    >
+    <pane id="mainContent" min-size="50" :size="85" class="main-content">
       <!-- image gallery grid. -->
       <render-window ref="renderWindow" id="renderWindow" class="plots" />
       <v-container v-bind:style="{padding: '0', maxWidth: '100%'}">

--- a/client/src/components/widgets/ContextMenu/script.js
+++ b/client/src/components/widgets/ContextMenu/script.js
@@ -88,6 +88,15 @@ export default {
         this.$store.getters[`${this.itemInfo?.id}/PLOT_DATA_COMPLETE`] || {}
       );
     },
+    logScaling() {
+      if (!this.itemInfo?.id) {
+        return false;
+      }
+
+      return (
+        this.$store.getters[`${this.itemInfo?.id}/PLOT_LOG_SCALING`] || false
+      );
+    },
   },
 
   methods: {
@@ -188,6 +197,14 @@ export default {
     canAverage() {
       const xAxis = this.itemInfo?.xAxis || "";
       return !xAxis.toLowerCase().includes("time") && this.itemInfo?.isPlotly;
+    },
+    toggleLogScale() {
+      if (this.itemInfo?.id) {
+        this.$store.commit(
+          `${this.itemInfo.id}/PLOT_LOG_SCALING_SET`,
+          !this.logScaling,
+        );
+      }
     },
   },
 };

--- a/client/src/components/widgets/ContextMenu/template.html
+++ b/client/src/components/widgets/ContextMenu/template.html
@@ -12,10 +12,10 @@
         <v-list-item dense @click="showRangeDialog=true">
           <v-list-item-title> Set global range </v-list-item-title>
         </v-list-item>
-        <v-list-item dense @click="toggleLogScale()">
+        <v-list-item dense @click="toggleLogScale">
           <v-list-item-title>
-            {{logScaling ? "Clear" : "Apply"}} log scaling</v-list-item-title
-          >
+            {{logScaling ? "Clear" : "Apply"}} log scaling
+          </v-list-item-title>
         </v-list-item>
       </v-list>
       <v-divider v-if="itemInfo && itemInfo.isPlotly" />

--- a/client/src/components/widgets/ContextMenu/template.html
+++ b/client/src/components/widgets/ContextMenu/template.html
@@ -12,6 +12,11 @@
         <v-list-item dense @click="showRangeDialog=true">
           <v-list-item-title> Set global range </v-list-item-title>
         </v-list-item>
+        <v-list-item dense @click="toggleLogScale()">
+          <v-list-item-title>
+            {{logScaling ? "Clear" : "Apply"}} log scaling</v-list-item-title
+          >
+        </v-list-item>
       </v-list>
       <v-divider v-if="itemInfo && itemInfo.isPlotly" />
       <v-list>

--- a/client/src/components/widgets/DownloadOptions/script.js
+++ b/client/src/components/widgets/DownloadOptions/script.js
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import { mapGetters, mapMutations } from "vuex";
+import { extractRange } from "../../../utils/helpers";
 
 export default {
   inject: ["girderRest"],
@@ -61,17 +62,17 @@ export default {
     },
     minStep() {
       if (this.id) {
-        return Math.min(
-          ...this.$store.getters[`${this.id}/PLOT_AVAILABLE_TIME_STEPS`],
-        );
+        let ats = this.$store.getters[`${this.id}/PLOT_AVAILABLE_TIME_STEPS`];
+        let [min] = extractRange(ats);
+        return min;
       }
       return 0;
     },
     maxStep() {
       if (this.id) {
-        return Math.max(
-          ...this.$store.getters[`${this.id}/PLOT_AVAILABLE_TIME_STEPS`],
-        );
+        let ats = this.$store.getters[`${this.id}/PLOT_AVAILABLE_TIME_STEPS`];
+        let [, max] = extractRange(ats);
+        return max;
       }
       return 0;
     },

--- a/client/src/components/widgets/LoadDialog/script.js
+++ b/client/src/components/widgets/LoadDialog/script.js
@@ -107,7 +107,6 @@ export default {
             log: data ? value.log : false,
             xAxis: data ? value.xAxis : "",
             range: data ? value.range : null,
-            legend: data ? value.legend : false,
           };
         }
       }

--- a/client/src/components/widgets/PlotlyPlot/script.js
+++ b/client/src/components/widgets/PlotlyPlot/script.js
@@ -56,11 +56,13 @@ export default {
       avgAnnotation: "",
       computingTimeAverage: false,
       plotLabels: {},
+      currentRange: null,
     };
   },
 
   computed: {
     ...mapGetters({
+      enableRangeTooltip: "UI_SHOW_RANGE_TOOLTIP",
       xaxisVisible: "UI_SHOW_X_AXIS",
       yaxisVisible: "UI_SHOW_Y_AXIS",
       showTitle: "UI_SHOW_TITLE",
@@ -310,6 +312,11 @@ export default {
       if (this.range) this.useGlobalRange(image);
       if (this.runGlobals) this.useRunGlobals(image);
       if (this.zoom) this.applyZoom(image);
+      const data = image.data[0];
+      const xRange = [Math.min(...data.x), Math.max(...data.y)];
+      let yRange = this.range;
+      if (!yRange) yRange = [Math.min(...data.y), Math.max(...data.y)];
+      this.currentRange = [...xRange, ...yRange];
       this.setAnnotations(image.data[0]);
       this.updatePlotDetails(image);
     },
@@ -467,12 +474,19 @@ export default {
         this.rangeText = "";
         return;
       }
-      const xRange = [data.x[0], data.x[data.x.length - 1]];
-      let yRange = this.range;
-      if (!yRange) yRange = [Math.min(...data.y), Math.max(...data.y)];
-      const range = [...xRange, ...yRange];
-      const [x0, x1, y0, y1] = range.map((r) => r.toPrecision(4));
+      const [x0, x1, y0, y1] = this.currentRange.map((r) => r.toPrecision(4));
       this.rangeText = `xRange: [${x0}, ${x1}] yRange: [${y0}, ${y1}]`;
+    },
+    tooltipText() {
+      let [x0, x1] = this.xRange;
+      let [y0, y1] = this.yRange;
+      if (!this.runGlobals && this.currentRange) {
+        [x0, x1, y0, y1] = this.currentRange;
+      }
+      return {
+        x: `[${x0.toExponential(3)}, ${x1.toExponential(3)}]`,
+        y: `[${y0.toExponential(3)}, ${y1.toExponential(3)}]`,
+      };
     },
   },
 

--- a/client/src/components/widgets/PlotlyPlot/script.js
+++ b/client/src/components/widgets/PlotlyPlot/script.js
@@ -469,7 +469,7 @@ export default {
       });
       this.timeIndex = this.times.findIndex((time) => time === closestVal);
     },
-    setAnnotations(data) {
+    setAnnotations() {
       if (!this.zoom) {
         this.rangeText = "";
         return;

--- a/client/src/components/widgets/PlotlyPlot/script.js
+++ b/client/src/components/widgets/PlotlyPlot/script.js
@@ -3,6 +3,7 @@ import { isEmpty, isEqual, isNil } from "lodash";
 import { mapActions, mapGetters, mapMutations } from "vuex";
 import { PlotType } from "../../../utils/constants";
 import Annotations from "../Annotations";
+import { extractRange } from "../../../utils/helpers";
 
 //-----------------------------------------------------------------------------
 // Utility Functions
@@ -313,9 +314,9 @@ export default {
       if (this.runGlobals) this.useRunGlobals(image);
       if (this.zoom) this.applyZoom(image);
       const data = image.data[0];
-      const xRange = [Math.min(...data.x), Math.max(...data.y)];
+      const xRange = extractRange(data.x);
       let yRange = this.range;
-      if (!yRange) yRange = [Math.min(...data.y), Math.max(...data.y)];
+      if (!yRange) yRange = extractRange(data.y);
       this.currentRange = [...xRange, ...yRange];
       this.setAnnotations(image.data[0]);
       this.updatePlotDetails(image);
@@ -330,10 +331,8 @@ export default {
           this.averagingValues = [];
         }
       } else {
-        let end = Math.min(
-          this.currentTimeStep + this.timeAverage,
-          Math.max(...this.availableTimeSteps),
-        );
+        let [, max] = extractRange(this.availableTimeSteps);
+        let end = Math.min(this.currentTimeStep + this.timeAverage, max);
         this.avgAnnotation = `Averaging Over Time Steps ${this.currentTimeStep} - ${end}`;
         this.averagingValues = [];
         for (

--- a/client/src/components/widgets/PlotlyPlot/script.js
+++ b/client/src/components/widgets/PlotlyPlot/script.js
@@ -375,7 +375,7 @@ export default {
       }
       return nextImage;
     },
-    react: function () {
+    react() {
       if (!this.itemId) {
         return;
       }

--- a/client/src/components/widgets/PlotlyPlot/script.js
+++ b/client/src/components/widgets/PlotlyPlot/script.js
@@ -64,6 +64,7 @@ export default {
       xaxisVisible: "UI_SHOW_X_AXIS",
       yaxisVisible: "UI_SHOW_Y_AXIS",
       showTitle: "UI_SHOW_TITLE",
+      legendVisibility: "UI_SHOW_LEGEND",
       runGlobals: "UI_USE_RUN_GLOBALS",
       syncZoom: "UI_ZOOM_SYNC",
       timeStepSelectorMode: "UI_TIME_STEP_SELECTOR",
@@ -75,11 +76,6 @@ export default {
     availableTimeSteps() {
       return (
         this.$store.getters[`${this.itemId}/PLOT_AVAILABLE_TIME_STEPS`] || []
-      );
-    },
-    legendVisibility() {
-      return (
-        this.$store.getters[`${this.itemId}/PLOT_LEGEND_VISIBILITY`] || false
       );
     },
     loadedTimeStepData() {
@@ -401,11 +397,6 @@ export default {
               icon: Plotly.Icons["3d_rotate"],
               click: this.toggleLogScale,
             },
-            {
-              name: "toggle legend visibility",
-              icon: Plotly.Icons["tooltip_basic"],
-              click: this.toggleLegendVisibility,
-            },
           ],
           modeBarButtonsToRemove: ["toImage"],
         });
@@ -495,12 +486,6 @@ export default {
       this.$store.commit(
         `${this.itemId}/PLOT_LOG_SCALING_SET`,
         !this.logScaling,
-      );
-    },
-    toggleLegendVisibility() {
-      this.$store.commit(
-        `${this.itemId}/PLOT_LEGEND_VISIBILITY_SET`,
-        !this.legendVisibility,
       );
     },
   },

--- a/client/src/components/widgets/PlotlyPlot/script.js
+++ b/client/src/components/widgets/PlotlyPlot/script.js
@@ -391,14 +391,6 @@ export default {
         };
         Plotly.react(this.$refs.plotly, nextImage.data, layout, {
           autosize: true,
-          modeBarButtonsToAdd: [
-            {
-              name: "toggle log scaling",
-              icon: Plotly.Icons["3d_rotate"],
-              click: this.toggleLogScale,
-            },
-          ],
-          modeBarButtonsToRemove: ["toImage"],
         });
         if (!this.eventHandlersSet) this.setEventHandlers();
         this.updateNumReady(this.numReady + 1);
@@ -481,12 +473,6 @@ export default {
       const range = [...xRange, ...yRange];
       const [x0, x1, y0, y1] = range.map((r) => r.toPrecision(4));
       this.rangeText = `xRange: [${x0}, ${x1}] yRange: [${y0}, ${y1}]`;
-    },
-    toggleLogScale() {
-      this.$store.commit(
-        `${this.itemId}/PLOT_LOG_SCALING_SET`,
-        !this.logScaling,
-      );
     },
   },
 

--- a/client/src/components/widgets/PlotlyPlot/template.html
+++ b/client/src/components/widgets/PlotlyPlot/template.html
@@ -10,9 +10,9 @@
     height="fit-content"
   >
     <template v-slot:activator="{ on }">
-      <v-icon v-on="on" :style="{position: 'absolute', right: '0', bottom: '0'}"
-        >mdi-information-variant</v-icon
-      >
+      <v-icon v-on="on" style="position: absolute; right: 0; bottom: 0">
+        mdi-information-variant
+      </v-icon>
     </template>
     <v-list>
       <v-list-item dense v-if="!xaxisVisible">

--- a/client/src/components/widgets/PlotlyPlot/template.html
+++ b/client/src/components/widgets/PlotlyPlot/template.html
@@ -1,4 +1,28 @@
 <div ref="plotly" class="plot">
+  <v-menu
+    v-if="enableRangeTooltip"
+    open-on-hover
+    offset-y
+    left
+    top
+    :close-on-content-click="false"
+    min-width="fit-content"
+    height="fit-content"
+  >
+    <template v-slot:activator="{ on }">
+      <v-icon v-on="on" :style="{position: 'absolute', right: '0', bottom: '0'}"
+        >mdi-information-variant</v-icon
+      >
+    </template>
+    <v-list>
+      <v-list-item dense v-if="!xaxisVisible">
+        <v-list-item-title>X Range: {{tooltipText().x}}</v-list-item-title>
+      </v-list-item>
+      <v-list-item dense v-if="!yaxisVisible">
+        <v-list-item-title>Y Range: {{tooltipText().y}}</v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </v-menu>
   <annotations
     v-if="rangeText.length"
     :text="rangeText"

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -418,6 +418,7 @@ export default {
       this.setMetaData({});
       this.itemId = "";
       this.setInitialLoad(true);
+      this.plotType = PlotType.None;
     },
     async setRun() {
       const { data } = await this.girderRest.get(

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -447,13 +447,8 @@ export default {
     },
   },
 
-  mounted() {
-    this.setGridSize(this.numcols * this.numrows);
-  },
-
   destroyed() {
     this.updateVisiblePlots({ newId: null, oldId: this.itemId });
-    this.setGridSize(this.gridSize - 1);
   },
 
   beforeDestroyed() {

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -142,7 +142,7 @@ export default {
       setShouldAutoSave: "VIEWS_AUTO_SAVE_RUN_SET",
       updateNumReady: "VIEW_NUM_READY_SET",
     }),
-    setMetaData: function (meta) {
+    setMetaData(meta) {
       if (!this.itemId) {
         return;
       }

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -159,9 +159,6 @@ export default {
 
       this.$store.commit(`${this.itemId}/PLOT_TIMES_SET`, times);
     },
-    updatePlotLegendVisibility: function (legend) {
-      this.$store.commit(`${this.itemId}/PLOT_LEGEND_VISIBILITY_SET`, legend);
-    },
     updatePlotLogScaling: function (log) {
       this.$store.commit(`${this.itemId}/PLOT_LOG_SCALING_SET`, log);
     },
@@ -317,7 +314,6 @@ export default {
       this.itemId = item.id || "";
       this.updateRegisteredModules(oldId);
       this.updateVisiblePlots({ newId: this.itemId, oldId });
-      this.updatePlotLegendVisibility(item.legend);
       this.updatePlotLogScaling(item.log);
       this.updatePlotXAxis(item.xAxis);
       this.updatePlotZoom(item.zoom);

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -97,7 +97,8 @@ export default {
         if (this.itemId) {
           this.plotFetcher = new PlotFetcher(
             this.itemId,
-            (itemId) => this.callFastEndpoint(`variables/${itemId}/timesteps`),
+            (itemId) =>
+              this.callFastEndpoint(`variables/${itemId}/timesteps/meta`),
             (itemId, timestep) =>
               this.callFastEndpoint(
                 `variables/${itemId}/timesteps/${timestep}/plot`,
@@ -141,15 +142,12 @@ export default {
       setShouldAutoSave: "VIEWS_AUTO_SAVE_RUN_SET",
       updateNumReady: "VIEW_NUM_READY_SET",
     }),
-    setAvailableTimeSteps: function (steps) {
+    setMetaData: function (meta) {
       if (!this.itemId) {
         return;
       }
 
-      this.$store.dispatch(
-        `${this.itemId}/PLOT_AVAILABLE_TIME_STEPS_CHANGED`,
-        steps,
-      );
+      this.$store.dispatch(`${this.itemId}/PLOT_META_DATA_CHANGED`, meta);
     },
     setLoadedTimeStepData: function (loaded) {
       this.$store.commit(`${this.itemId}/PLOT_LOADED_TIME_STEPS_SET`, loaded);
@@ -261,8 +259,8 @@ export default {
       const firstAvailableStep = await this.plotFetcher
         .initialize()
         .then((response) => {
+          this.setMetaData(response);
           ats = response.steps.sort((a, b) => a - b);
-          this.setAvailableTimeSteps(ats);
           this.updateTimes(response.time);
           // Make sure there is an image associated with this time step
           let step = ats.find((step) => step === this.currentTimeStep);
@@ -421,7 +419,7 @@ export default {
     },
     clearGallery() {
       this.updateVisiblePlots({ newId: null, oldId: this.itemId });
-      this.setAvailableTimeSteps([]);
+      this.setMetaData({});
       this.itemId = "";
       this.setInitialLoad(true);
     },

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -7,6 +7,7 @@ import { PlotType } from "../../../utils/constants";
 import { PlotFetcher } from "../../../utils/plotFetcher";
 
 import plot from "../../../store/plot";
+import { extractRange } from "../../../utils/helpers";
 
 // // Number of timesteps to prefetch data for.
 // const TIMESTEPS_TO_PREFETCH = 3;
@@ -276,7 +277,8 @@ export default {
       );
       await this.plotFetcher.fetchTimeStepFn(response, firstAvailableStep);
 
-      this.setMaxTimeStep(Math.max(this.maxTimeStep, Math.max(...ats)));
+      let [, max] = extractRange(ats);
+      this.setMaxTimeStep(Math.max(this.maxTimeStep, max));
       this.setItemId(this.itemId);
       this.setInitialLoad(false);
       this.$refs[`${this.row}-${this.col}`].react();

--- a/client/src/components/widgets/SettingsPanel/script.js
+++ b/client/src/components/widgets/SettingsPanel/script.js
@@ -14,15 +14,6 @@ export default {
     return {
       showSaveDialog: false,
       showLoadDialog: false,
-      zoomSync: true,
-      selectTimeStep: false,
-      autoSavePrompt: true,
-      runGlobals: true,
-      xAxis: false,
-      yAxis: false,
-      scalarBar: false,
-      title: false,
-      legend: false,
     };
   },
 
@@ -30,36 +21,6 @@ export default {
     plots: {
       type: Array,
       default: () => [],
-    },
-  },
-
-  watch: {
-    zoomSync() {
-      this.toggleSyncZoom();
-    },
-    selectTimeStep() {
-      this.toggleSelectTimeStep();
-    },
-    autoSavePrompt(status) {
-      this.setAutoSaveDialogEnabled(status);
-    },
-    runGlobals() {
-      this.toggleRunGlobals();
-    },
-    xAxis() {
-      this.toggleXAxis();
-    },
-    yAxis() {
-      this.toggleYAxis();
-    },
-    scalarBar() {
-      this.toggleScalarBar();
-    },
-    title() {
-      this.toggleTitle();
-    },
-    legend() {
-      this.toggleLegend();
     },
   },
 
@@ -96,6 +57,14 @@ export default {
 
   computed: {
     ...mapGetters({
+      showLegend: "UI_SHOW_LEGEND",
+      showScalarBar: "UI_SHOW_SCALAR_BAR",
+      showYAxis: "UI_SHOW_Y_AXIS",
+      showXAxis: "UI_SHOW_X_AXIS",
+      useRunGlobals: "UI_USE_RUN_GLOBALS",
+      showAutoSaveDialog: "UI_AUTO_SAVE_DIALOG_ENABLED",
+      syncZoom: "UI_ZOOM_SYNC",
+      showTitle: "UI_SHOW_TITLE",
       showSettings: "UI_SHOW_SETTINGS",
       timeStepSelectorMode: "UI_TIME_STEP_SELECTOR",
       lastSaved: "VIEWS_LAST_SAVED",
@@ -105,5 +74,77 @@ export default {
       simulation: "VIEWS_SIMULATION",
       step: "VIEW_TIME_STEP",
     }),
+    zoomSync: {
+      get() {
+        return this.syncZoom;
+      },
+      set() {
+        this.toggleSyncZoom();
+      },
+    },
+    selectTimeStep: {
+      get() {
+        return this.timeStepSelectorMode;
+      },
+      set() {
+        this.toggleSelectTimeStep();
+      },
+    },
+    autoSavePrompt: {
+      get() {
+        return this.showAutoSaveDialog;
+      },
+      set(val) {
+        this.setAutoSaveDialogEnabled(val);
+      },
+    },
+    runGlobals: {
+      get() {
+        return this.useRunGlobals;
+      },
+      set() {
+        this.toggleRunGlobals();
+      },
+    },
+    xAxis: {
+      get() {
+        return this.showXAxis;
+      },
+      set() {
+        this.toggleXAxis();
+      },
+    },
+    yAxis: {
+      get() {
+        return this.showYAxis;
+      },
+      set() {
+        this.toggleYAxis();
+      },
+    },
+    scalarBar: {
+      get() {
+        return this.showScalarBar;
+      },
+      set() {
+        this.toggleScalarBar();
+      },
+    },
+    legend: {
+      get() {
+        return this.showLegend;
+      },
+      set() {
+        this.toggleLegend();
+      },
+    },
+    title: {
+      get() {
+        return this.showTitle;
+      },
+      set() {
+        this.toggleTitle();
+      },
+    },
   },
 };

--- a/client/src/components/widgets/SettingsPanel/script.js
+++ b/client/src/components/widgets/SettingsPanel/script.js
@@ -22,6 +22,7 @@ export default {
       yAxis: false,
       scalarBar: false,
       title: false,
+      legend: false,
     };
   },
 
@@ -57,6 +58,9 @@ export default {
     title() {
       this.toggleTitle();
     },
+    legend() {
+      this.toggleLegend();
+    },
   },
 
   methods: {
@@ -70,6 +74,7 @@ export default {
       toggleYAxis: "UI_TOGGLE_Y_AXIS",
       toggleScalarBar: "UI_TOGGLE_SCALAR_BAR",
       toggleTitle: "UI_TOGGLE_TITLE",
+      toggleLegend: "UI_TOGGLE_LEGEND",
     }),
     ...mapMutations({
       setPaused: "UI_PAUSE_GALLERY_SET",

--- a/client/src/components/widgets/SettingsPanel/script.js
+++ b/client/src/components/widgets/SettingsPanel/script.js
@@ -43,6 +43,7 @@ export default {
       setSaveDialogVisible: "UI_SHOW_SAVE_DIALOG_SET",
       toggleSettingsVisibility: "UI_SHOW_SETTINGS_SET",
       setAutoSaveDialogEnabled: "UI_AUTO_SAVE_DIALOG_ENABLED_SET",
+      setRangeTooltipEnabled: "UI_SHOW_RANGE_TOOLTIP_SET",
     }),
     async saveView() {
       await this.fetchAllViews();
@@ -57,6 +58,7 @@ export default {
 
   computed: {
     ...mapGetters({
+      enableRangeTooltip: "UI_SHOW_RANGE_TOOLTIP",
       showLegend: "UI_SHOW_LEGEND",
       showScalarBar: "UI_SHOW_SCALAR_BAR",
       showYAxis: "UI_SHOW_Y_AXIS",
@@ -144,6 +146,14 @@ export default {
       },
       set() {
         this.toggleTitle();
+      },
+    },
+    rangeInfo: {
+      get() {
+        return this.enableRangeTooltip;
+      },
+      set(val) {
+        this.setRangeTooltipEnabled(val);
       },
     },
   },

--- a/client/src/components/widgets/SettingsPanel/script.js
+++ b/client/src/components/widgets/SettingsPanel/script.js
@@ -17,6 +17,11 @@ export default {
       zoomSync: true,
       selectTimeStep: false,
       autoSavePrompt: true,
+      runGlobals: true,
+      xAxis: false,
+      yAxis: false,
+      scalarBar: false,
+      title: false,
     };
   },
 
@@ -37,6 +42,21 @@ export default {
     autoSavePrompt(status) {
       this.setAutoSaveDialogEnabled(status);
     },
+    runGlobals() {
+      this.toggleRunGlobals();
+    },
+    xAxis() {
+      this.toggleXAxis();
+    },
+    yAxis() {
+      this.toggleYAxis();
+    },
+    scalarBar() {
+      this.toggleScalarBar();
+    },
+    title() {
+      this.toggleTitle();
+    },
   },
 
   methods: {
@@ -45,6 +65,11 @@ export default {
       toggleSelectTimeStep: "UI_TOGGLE_TIME_STEP",
       fetchAllViews: "VIEWS_FETCH_ALL_AVAILABLE",
       toggleShowSettings: "UI_TOGGLE_SHOW_SETTINGS",
+      toggleRunGlobals: "UI_TOGGLE_RUN_GLOBALS",
+      toggleXAxis: "UI_TOGGLE_X_AXIS",
+      toggleYAxis: "UI_TOGGLE_Y_AXIS",
+      toggleScalarBar: "UI_TOGGLE_SCALAR_BAR",
+      toggleTitle: "UI_TOGGLE_TITLE",
     }),
     ...mapMutations({
       setPaused: "UI_PAUSE_GALLERY_SET",

--- a/client/src/components/widgets/SettingsPanel/template.html
+++ b/client/src/components/widgets/SettingsPanel/template.html
@@ -171,6 +171,25 @@
           </v-tooltip>
         </v-col>
       </v-row>
+      <v-row>
+        <v-col>
+          <v-tooltip left bottom>
+            <template v-slot:activator="{on, attrs}">
+              <div v-on="on" v-bind="attrs">
+                <v-switch
+                  dense
+                  v-model="rangeInfo"
+                  label="range info"
+                  hide-details
+                />
+              </div>
+            </template>
+            <p class="mb-0">
+              Range info on hover {{rangeInfo ? "enabled" : "disabled"}}.
+            </p>
+          </v-tooltip>
+        </v-col>
+      </v-row>
     </v-col>
   </div>
   <v-row class="ma-0 pa-0" :style="{height: '25px'}">

--- a/client/src/components/widgets/SettingsPanel/template.html
+++ b/client/src/components/widgets/SettingsPanel/template.html
@@ -27,7 +27,7 @@
       <v-divider />
       <v-row>
         <v-col sm="6">
-          <v-tooltip left>
+          <v-tooltip left bottom>
             <template v-slot:activator="{on, attrs}">
               <div v-on="on" v-bind="attrs">
                 <v-switch v-model="zoomSync" label="Sync zoom" hide-details />
@@ -38,7 +38,7 @@
           </v-tooltip>
         </v-col>
         <v-col sm="6">
-          <v-tooltip right>
+          <v-tooltip left bottom>
             <template v-slot:activator="{on, attrs}">
               <div v-on="on" v-bind="attrs">
                 <v-switch
@@ -57,7 +57,7 @@
       <v-divider />
       <v-row>
         <v-col sm="12">
-          <v-tooltip left>
+          <v-tooltip left bottom>
             <template v-slot:activator="{on, attrs}">
               <div v-on="on" v-bind="attrs">
                 <v-switch label="View completed runs" hide-details disabled />
@@ -71,7 +71,7 @@
       <v-divider />
       <v-row>
         <v-col sm="12">
-          <v-tooltip left>
+          <v-tooltip left bottom>
             <template v-slot:activator="{on, attrs}">
               <div v-on="on" v-bind="attrs">
                 <v-switch
@@ -82,10 +82,80 @@
               </div>
             </template>
             <p class="mb-0">
-              {{autoSavePrompt ? "Do not show" : "Show"}} the prompt asking if
-              you would
+              {{autoSavePrompt ? "Hiding" : "Showing"}} the prompt asking if you
+              would
             </p>
             <p class="mb-0">like to load the last auto-saved layout.</p>
+          </v-tooltip>
+        </v-col>
+      </v-row>
+      <v-subheader> Plots </v-subheader>
+      <v-divider />
+      <v-row>
+        <v-col>
+          <v-tooltip left bottom>
+            <template v-slot:activator="{on, attrs}">
+              <div v-on="on" v-bind="attrs">
+                <v-switch dense v-model="xAxis" label="x-axis" hide-details />
+              </div>
+            </template>
+            <p class="mb-0">{{xAxis ? "Showing" : "Hiding"}} the x axis.</p>
+          </v-tooltip>
+        </v-col>
+        <v-col>
+          <v-tooltip left bottom>
+            <template v-slot:activator="{on, attrs}">
+              <div v-on="on" v-bind="attrs">
+                <v-switch dense v-model="yAxis" label="y-axis" hide-details />
+              </div>
+            </template>
+            <p class="mb-0">{{yAxis ? "Showing" : "Hiding"}} the y axis.</p>
+          </v-tooltip>
+        </v-col>
+        <v-col>
+          <v-tooltip left bottom>
+            <template v-slot:activator="{on, attrs}">
+              <div v-on="on" v-bind="attrs">
+                <v-switch
+                  dense
+                  v-model="scalarBar"
+                  label="scalar bar"
+                  hide-details
+                />
+              </div>
+            </template>
+            <p class="mb-0">
+              {{scalarBar ? "Showing" : "Hiding"}} the scalar bar.
+            </p>
+          </v-tooltip>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col>
+          <v-tooltip left bottom>
+            <template v-slot:activator="{on, attrs}">
+              <div v-on="on" v-bind="attrs">
+                <v-switch dense v-model="title" label="title" hide-details />
+              </div>
+            </template>
+            <p class="mb-0">{{title ? "Showing" : "Hiding"}} the plot title.</p>
+          </v-tooltip>
+        </v-col>
+        <v-col>
+          <v-tooltip left bottom>
+            <template v-slot:activator="{on, attrs}">
+              <div v-on="on" v-bind="attrs">
+                <v-switch
+                  dense
+                  v-model="runGlobals"
+                  label="global values"
+                  hide-details
+                />
+              </div>
+            </template>
+            <p class="mb-0">
+              Using {{runGlobals ? "global" : "time step"}} ranges.
+            </p>
           </v-tooltip>
         </v-col>
       </v-row>

--- a/client/src/components/widgets/SettingsPanel/template.html
+++ b/client/src/components/widgets/SettingsPanel/template.html
@@ -145,6 +145,18 @@
           <v-tooltip left bottom>
             <template v-slot:activator="{on, attrs}">
               <div v-on="on" v-bind="attrs">
+                <v-switch dense v-model="legend" label="legend" hide-details />
+              </div>
+            </template>
+            <p class="mb-0">
+              {{legend ? "Showing" : "Hiding"}} the plot legend.
+            </p>
+          </v-tooltip>
+        </v-col>
+        <v-col>
+          <v-tooltip left bottom>
+            <template v-slot:activator="{on, attrs}">
+              <div v-on="on" v-bind="attrs">
                 <v-switch
                   dense
                   v-model="runGlobals"

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -56,11 +56,16 @@ export default {
       rangeText: "",
       plotType: null,
       lastLoadedTimeStep: -1,
+      currentRange: null,
     };
   },
 
   computed: {
     ...mapGetters({
+      enableRangeTooltip: "UI_SHOW_RANGE_TOOLTIP",
+      xaxisVisible: "UI_SHOW_X_AXIS",
+      yaxisVisible: "UI_SHOW_Y_AXIS",
+      showScalarBar: "UI_SHOW_SCALAR_BAR",
       renderWindow: "UI_RENDER_WINDOW",
       syncZoom: "UI_ZOOM_SYNC",
       interactor: "UI_INTERACTOR",
@@ -82,6 +87,15 @@ export default {
     },
     xAxis() {
       return this.$store.getters[`${this.itemId}/PLOT_X_AXIS`] || null;
+    },
+    scalarRange() {
+      return this.$store.getters[`${this.itemId}/PLOT_COLOR_RANGE`] || null;
+    },
+    xRange() {
+      return this.$store.getters[`${this.itemId}/PLOT_X_RANGE`] || null;
+    },
+    yRange() {
+      return this.$store.getters[`${this.itemId}/PLOT_Y_RANGE`] || null;
     },
     zoom() {
       return this.$store.getters[`${this.itemId}/PLOT_ZOOM`] || null;
@@ -122,6 +136,27 @@ export default {
           this.removeRenderer();
           this.lastLoadedTimeStep = -1;
         }
+      },
+    },
+    xaxisVisible: {
+      immediate: true,
+      handler(newVal, oldVal) {
+        let forceRerender = !isEqual(newVal, oldVal);
+        this.react(forceRerender);
+      },
+    },
+    yaxisVisible: {
+      immediate: true,
+      handler(newVal, oldVal) {
+        let forceRerender = !isEqual(newVal, oldVal);
+        this.react(forceRerender);
+      },
+    },
+    showScalarBar: {
+      immediate: true,
+      handler(newVal, oldVal) {
+        let forceRerender = !isEqual(newVal, oldVal);
+        this.react(forceRerender);
       },
     },
   },
@@ -598,6 +633,20 @@ export default {
           this.camera.setParallelScale(this.zoom.scale);
         }
       }
+    },
+    tooltipText() {
+      let [x0, x1] = this.xRange;
+      let [y0, y1] = this.yRange;
+      let [s0, s1] = this.scalarRange;
+      if (!this.runGlobals && this.currentRange) {
+        [x0, x1, y0, y1] = this.currentRange;
+        [s0, s1] = this.mapper.getScalarRange();
+      }
+      return {
+        x: `[${x0.toExponential(3)}, ${x1.toExponential(3)}]`,
+        y: `[${y0.toExponential(3)}, ${y1.toExponential(3)}]`,
+        scalar: `[${s0.toExponential(3)}, ${s1.toExponential(3)}]`,
+      };
     },
   },
 

--- a/client/src/components/widgets/VTKPlot/script.js
+++ b/client/src/components/widgets/VTKPlot/script.js
@@ -20,6 +20,7 @@ import vtkPolyData from "@kitware/vtk.js/Common/DataModel/PolyData";
 import vtkRenderer from "@kitware/vtk.js/Rendering/Core/Renderer";
 import vtkScalarBarActor from "@kitware/vtk.js/Rendering/Core/ScalarBarActor";
 import vtkCustomCubeAxesActor from "../../../utils/vtkCustomCubeAxesActor";
+import { extractRange } from "../../../utils/helpers";
 
 const Y_AXES_LABEL_BOUNDS_ADJUSTMENT = 0.001;
 const MESH_XAXIS_SCALE_OFFSET = 0.1;
@@ -698,12 +699,8 @@ export default {
       this.renderer.resetCamera(bounds);
     },
     actorScale(xVals, yVals) {
-      const [x0, x1] = this.runGlobals
-        ? this.xRange
-        : [Math.min(...xVals), Math.max(...xVals)];
-      const [y0, y1] = this.runGlobals
-        ? this.yRange
-        : [Math.min(...yVals), Math.max(...yVals)];
+      const [x0, x1] = this.runGlobals ? this.xRange : extractRange(xVals);
+      const [y0, y1] = this.runGlobals ? this.yRange : extractRange(yVals);
       this.currentRange = [x0, x1, y0, y1];
       return (y1 - y0) / (x1 - x0);
     },

--- a/client/src/components/widgets/VTKPlot/template.html
+++ b/client/src/components/widgets/VTKPlot/template.html
@@ -10,9 +10,9 @@
     height="fit-content"
   >
     <template v-slot:activator="{ on }">
-      <v-icon v-on="on" :style="{position: 'absolute', right: '0', bottom: '0'}"
-        >mdi-information-variant</v-icon
-      >
+      <v-icon v-on="on" style="position: absolute; right: 0; bottom: 0">
+        mdi-information-variant
+      </v-icon>
     </template>
     <v-list>
       <v-list-item dense v-if="!xaxisVisible">
@@ -22,9 +22,9 @@
         <v-list-item-title>Y Range: {{tooltipText().y}}</v-list-item-title>
       </v-list-item>
       <v-list-item dense v-if="!showScalarBar">
-        <v-list-item-title
-          >Scalar Range: {{tooltipText().scalar}}</v-list-item-title
-        >
+        <v-list-item-title>
+          Scalar Range: {{tooltipText().scalar}}
+        </v-list-item-title>
       </v-list-item>
     </v-list>
   </v-menu>

--- a/client/src/components/widgets/VTKPlot/template.html
+++ b/client/src/components/widgets/VTKPlot/template.html
@@ -1,4 +1,33 @@
 <div ref="vtk" class="plot">
+  <v-menu
+    v-if="enableRangeTooltip"
+    open-on-hover
+    offset-y
+    left
+    top
+    :close-on-content-click="false"
+    min-width="fit-content"
+    height="fit-content"
+  >
+    <template v-slot:activator="{ on }">
+      <v-icon v-on="on" :style="{position: 'absolute', right: '0', bottom: '0'}"
+        >mdi-information-variant</v-icon
+      >
+    </template>
+    <v-list>
+      <v-list-item dense v-if="!xaxisVisible">
+        <v-list-item-title>X Range: {{tooltipText().x}}</v-list-item-title>
+      </v-list-item>
+      <v-list-item dense v-if="!yaxisVisible">
+        <v-list-item-title>Y Range: {{tooltipText().y}}</v-list-item-title>
+      </v-list-item>
+      <v-list-item dense v-if="!showScalarBar">
+        <v-list-item-title
+          >Scalar Range: {{tooltipText().scalar}}</v-list-item-title
+        >
+      </v-list-item>
+    </v-list>
+  </v-menu>
   <annotations
     v-if="rangeText.length  && itemId"
     :text="rangeText"

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -126,15 +126,8 @@
 // Make sure toolbar doesn't cover plot title
 // when visible
 .show-toolbar {
-  .modebar-container {
-    display: flex;
-    height: auto;
-    div {
-      height: auto;
-    }
-  }
   .modebar {
-    top: 20px !important;
+    display: none;
   }
 }
 

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -146,6 +146,7 @@
   min-width: 3px;
   width: 10px;
   background: linear-gradient(90deg, #ccc, #a5a4a4);
+  z-index: 1;
 }
 
 // Resize plot labels when plots resize

--- a/client/src/store/plot.js
+++ b/client/src/store/plot.js
@@ -10,6 +10,9 @@ export default {
     times: null,
     loadedTimeStepData: null,
     availableTimeSteps: null,
+    xRange: null,
+    yRange: null,
+    colorRange: null,
   }),
   getters: {
     PLOT_LEGEND_VISIBILITY(state) {
@@ -42,6 +45,15 @@ export default {
     PLOT_AVAILABLE_TIME_STEPS(state) {
       return state.availableTimeSteps;
     },
+    PLOT_X_RANGE(state) {
+      return state.xRange;
+    },
+    PLOT_Y_RANGE(state) {
+      return state.yRange;
+    },
+    PLOT_COLOR_RANGE(state) {
+      return state.colorRange;
+    },
   },
   mutations: {
     PLOT_LEGEND_VISIBILITY_SET(state, val) {
@@ -70,6 +82,15 @@ export default {
     },
     PLOT_AVAILABLE_TIME_STEPS_SET(state, val) {
       state.availableTimeSteps = val;
+    },
+    PLOT_X_RANGE_SET(state, val) {
+      state.xRange = val;
+    },
+    PLOT_Y_RANGE_SET(state, val) {
+      state.yRange = val;
+    },
+    PLOT_COLOR_RANGE_SET(state, val) {
+      state.colorRange = val;
     },
   },
   actions: {
@@ -110,6 +131,19 @@ export default {
         let timeStep = rootGetters.VIEW_TIME_STEP;
         let newCurr = Math.max(Math.min(timeStep, newMax), newMin);
         commit("VIEW_TIME_STEP_SET", newCurr, { root: true });
+      }
+    },
+    PLOT_META_DATA_CHANGED({ commit, dispatch }, meta) {
+      dispatch("PLOT_AVAILABLE_TIME_STEPS_CHANGED", meta.steps);
+
+      if (meta?.x_range) {
+        commit("PLOT_X_RANGE_SET", meta.x_range);
+      }
+      if (meta?.y_range) {
+        commit("PLOT_Y_RANGE_SET", meta.y_range);
+      }
+      if (meta?.color_range) {
+        commit("PLOT_COLOR_RANGE_SET", meta.color_range);
       }
     },
   },

--- a/client/src/store/plot.js
+++ b/client/src/store/plot.js
@@ -1,3 +1,5 @@
+import { extractRange } from "../utils/helpers";
+
 export default {
   namespaced: true,
   state: () => ({
@@ -111,9 +113,7 @@ export default {
       let newMax = -Infinity;
       rootGetters.VIEW_SELECTIONS.forEach((id) => {
         let steps = rootGetters[`${id}/PLOT_AVAILABLE_TIME_STEPS`] || [];
-        let tsMin = Math.min(...steps);
-        let tsMax = Math.max(...steps);
-
+        let [tsMin, tsMax] = extractRange(steps);
         newMin = Math.min(newMin, tsMin);
         newMax = Math.max(newMax, tsMax);
       });

--- a/client/src/store/plot.js
+++ b/client/src/store/plot.js
@@ -1,7 +1,6 @@
 export default {
   namespaced: true,
   state: () => ({
-    legend: false,
     log: false,
     range: null,
     timeAverage: 0,
@@ -15,9 +14,6 @@ export default {
     colorRange: null,
   }),
   getters: {
-    PLOT_LEGEND_VISIBILITY(state) {
-      return state.legend;
-    },
     PLOT_LOG_SCALING(state) {
       return state.log;
     },
@@ -56,9 +52,6 @@ export default {
     },
   },
   mutations: {
-    PLOT_LEGEND_VISIBILITY_SET(state, val) {
-      state.legend = val;
-    },
     PLOT_LOG_SCALING_SET(state, val) {
       state.log = val;
     },
@@ -95,7 +88,6 @@ export default {
   },
   actions: {
     PLOT_DATA_RESET({ commit }) {
-      commit("PLOT_LEGEND_VISIBILITY_SET", false);
       commit("PLOT_LOG_SCALING_SET", false);
       commit("PLOT_GLOBAL_RANGE_SET", null);
       commit("PLOT_TIME_AVERAGE_SET", 0);

--- a/client/src/store/ui.js
+++ b/client/src/store/ui.js
@@ -25,6 +25,11 @@ export default {
     boxSelector: null,
     showSettings: false,
     autoSavedViewDialogEnabled: true,
+    useRunGlobals: true,
+    showXAxis: false,
+    showYAxis: false,
+    showScalarBar: false,
+    showTitle: false,
   },
   getters: {
     UI_AUTO_SAVE_DIALOG(state) {
@@ -75,6 +80,21 @@ export default {
     UI_AUTO_SAVE_DIALOG_ENABLED(state) {
       return state.autoSavedViewDialogEnabled;
     },
+    UI_USE_RUN_GLOBALS(state) {
+      return state.useRunGlobals;
+    },
+    UI_SHOW_X_AXIS(state) {
+      return state.showXAxis;
+    },
+    UI_SHOW_Y_AXIS(state) {
+      return state.showYAxis;
+    },
+    UI_SHOW_SCALAR_BAR(state) {
+      return state.showScalarBar;
+    },
+    UI_SHOW_TITLE(state) {
+      return state.showTitle;
+    },
   },
   mutations: {
     UI_AUTO_SAVE_DIALOG_SET(state, val) {
@@ -122,6 +142,21 @@ export default {
     UI_AUTO_SAVE_DIALOG_ENABLED_SET(state, val) {
       state.autoSavedViewDialogEnabled = val;
     },
+    UI_USE_RUN_GLOBALS_SET(state, val) {
+      state.useRunGlobals = val;
+    },
+    UI_SHOW_X_AXIS_SET(state, val) {
+      state.showXAxis = val;
+    },
+    UI_SHOW_Y_AXIS_SET(state, val) {
+      state.showYAxis = val;
+    },
+    UI_SHOW_SCALAR_BAR_SET(state, val) {
+      state.showScalarBar = val;
+    },
+    UI_SHOW_TITLE(state, val) {
+      state.showTitle = val;
+    },
   },
   actions: {
     UI_TOGGLE_PLAY_PAUSE({ state }) {
@@ -135,6 +170,21 @@ export default {
     },
     UI_TOGGLE_SHOW_SETTINGS({ state }) {
       state.showSettings = !state.showSettings;
+    },
+    UI_TOGGLE_RUN_GLOBALS({ state }) {
+      state.useRunGlobals = !state.useRunGlobals;
+    },
+    UI_TOGGLE_X_AXIS({ state }) {
+      state.showXAxis = !state.showXAxis;
+    },
+    UI_TOGGLE_Y_AXIS({ state }) {
+      state.showYAxis = !state.showYAxis;
+    },
+    UI_TOGGLE_SCALAR_BAR({ state }) {
+      state.showScalarBar = !state.showScalarBar;
+    },
+    UI_TOGGLE_TITLE({ state }) {
+      state.showTitle = !state.showTitle;
     },
   },
 };

--- a/client/src/store/ui.js
+++ b/client/src/store/ui.js
@@ -29,7 +29,7 @@ export default {
     showXAxis: false,
     showYAxis: false,
     showScalarBar: false,
-    showTitle: false,
+    showTitle: true,
     showLegend: false,
     rangeTooltip: true,
   },

--- a/client/src/store/ui.js
+++ b/client/src/store/ui.js
@@ -30,6 +30,7 @@ export default {
     showYAxis: false,
     showScalarBar: false,
     showTitle: false,
+    showLegend: false,
   },
   getters: {
     UI_AUTO_SAVE_DIALOG(state) {
@@ -95,6 +96,9 @@ export default {
     UI_SHOW_TITLE(state) {
       return state.showTitle;
     },
+    UI_SHOW_LEGEND(state) {
+      return state.showLegend;
+    },
   },
   mutations: {
     UI_AUTO_SAVE_DIALOG_SET(state, val) {
@@ -154,8 +158,11 @@ export default {
     UI_SHOW_SCALAR_BAR_SET(state, val) {
       state.showScalarBar = val;
     },
-    UI_SHOW_TITLE(state, val) {
+    UI_SHOW_TITLE_SET(state, val) {
       state.showTitle = val;
+    },
+    UI_SHOW_LEGEND_SET(state, val) {
+      state.showLegend = val;
     },
   },
   actions: {
@@ -185,6 +192,9 @@ export default {
     },
     UI_TOGGLE_TITLE({ state }) {
       state.showTitle = !state.showTitle;
+    },
+    UI_TOGGLE_LEGEND({ state }) {
+      state.showLegend = !state.showLegend;
     },
   },
 };

--- a/client/src/store/ui.js
+++ b/client/src/store/ui.js
@@ -31,6 +31,7 @@ export default {
     showScalarBar: false,
     showTitle: false,
     showLegend: false,
+    rangeTooltip: true,
   },
   getters: {
     UI_AUTO_SAVE_DIALOG(state) {
@@ -99,6 +100,9 @@ export default {
     UI_SHOW_LEGEND(state) {
       return state.showLegend;
     },
+    UI_SHOW_RANGE_TOOLTIP(state) {
+      return state.rangeTooltip;
+    },
   },
   mutations: {
     UI_AUTO_SAVE_DIALOG_SET(state, val) {
@@ -163,6 +167,9 @@ export default {
     },
     UI_SHOW_LEGEND_SET(state, val) {
       state.showLegend = val;
+    },
+    UI_SHOW_RANGE_TOOLTIP_SET(state, val) {
+      state.rangeTooltip = val;
     },
   },
   actions: {

--- a/client/src/store/views.js
+++ b/client/src/store/views.js
@@ -200,8 +200,8 @@ export default {
       });
       commit("VIEWS_INFO_SET", info);
     },
-    async VIEW_FETCH_AUTO_SAVE({ state, commit, getters }) {
-      commit("VIEW_AUTO_SAVE_RUN_SET", false);
+    async VIEWS_FETCH_AUTO_SAVE({ state, commit, getters }) {
+      commit("VIEWS_AUTO_SAVE_RUN_SET", false);
       const userId = this.$girderRest.user._id;
       const viewName = `${state.simulation}_${state.runId}_${userId}`;
       commit("VIEWS_AUTO_SAVE_NAME_SET", viewName);
@@ -210,7 +210,7 @@ export default {
       );
       const view = data[0];
       if (view) {
-        commit("VIEW_AUTO_SAVED_SET", view);
+        commit("VIEWS_AUTO_SAVED_SET", view);
         // Show the auto-save dialog if it hasn't been disabled in the settings
         commit("UI_AUTO_SAVE_DIALOG_SET", getters.UI_AUTO_SAVE_DIALOG_ENABLED);
       }

--- a/client/src/store/views.js
+++ b/client/src/store/views.js
@@ -168,11 +168,10 @@ export default {
       layout.forEach((item) => {
         const { row, col, itemId } = item;
         if (itemId) {
-          const { legend, log, range, xAxis, zoom } =
+          const { log, range, xAxis, zoom } =
             getters[`${itemId}/PLOT_DATA_COMPLETE`];
           items[`${row}::${col}`] = {
             id: itemId,
-            legend,
             log,
             range,
             xAxis,

--- a/client/src/store/views.js
+++ b/client/src/store/views.js
@@ -168,14 +168,13 @@ export default {
       layout.forEach((item) => {
         const { row, col, itemId } = item;
         if (itemId) {
-          const { log, range, xAxis, zoom } =
-            getters[`${itemId}/PLOT_DATA_COMPLETE`];
+          const plotData = getters[`${itemId}/PLOT_DATA_COMPLETE`];
           items[`${row}::${col}`] = {
             id: itemId,
-            log,
-            range,
-            xAxis,
-            zoom,
+            log: plotData?.log || false,
+            range: plotData?.range || null,
+            xAxis: plotData?.xAxis || "",
+            zoom: plotData?.zoom || null,
           };
         }
       });

--- a/client/src/utils/helpers.js
+++ b/client/src/utils/helpers.js
@@ -1,0 +1,13 @@
+export function extractRange(array) {
+  let minValue = array[0];
+  let maxValue = array[0];
+  for (let i = 0; i < array.length; i++) {
+    const v = array[i];
+    if (v < minValue) {
+      minValue = v;
+    } else if (v > maxValue) {
+      maxValue = v;
+    }
+  }
+  return [minValue, maxValue];
+}

--- a/client/src/utils/vtkCustomCubeAxesActor.js
+++ b/client/src/utils/vtkCustomCubeAxesActor.js
@@ -3,7 +3,7 @@ import vtkCubeAxesActor from "@kitware/vtk.js/Rendering/Core/CubeAxesActor";
 import * as d3 from "d3-scale";
 
 const facesToDraw = [false, false, false, false, false, true];
-const edgesToDraw = [0, 0, 0, 0, 1, 2, 2, 1, 0, 0, 0, 0];
+const edgesToDraw = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
 function vtkCustomCubeAxesActor(publicAPI, model) {
   model.classHierarchy.push("vtkCustomCubeAxesActor");
@@ -47,8 +47,8 @@ function vtkCustomCubeAxesActor(publicAPI, model) {
 
       const [showX, showY] = model.visibleLabels;
       let edges = [...edgesToDraw];
-      edges[4] = showX ? 1 : 2;
-      edges[7] = showY ? 1 : 2;
+      edges[4] = showX ? 1 : 0;
+      edges[7] = showY ? 1 : 0;
 
       // update gridlines / edge lines
       publicAPI.updatePolyData(facesToDraw, edges, ticks);

--- a/client/src/utils/vtkCustomCubeAxesActor.js
+++ b/client/src/utils/vtkCustomCubeAxesActor.js
@@ -45,11 +45,16 @@ function vtkCustomCubeAxesActor(publicAPI, model) {
       tickStrings[2] = ["0"];
       ticks[2] = [0];
 
+      const [showX, showY] = model.visibleLabels;
+      let edges = [...edgesToDraw];
+      edges[4] = showX ? 1 : 2;
+      edges[7] = showY ? 1 : 2;
+
       // update gridlines / edge lines
-      publicAPI.updatePolyData(facesToDraw, edgesToDraw, ticks);
+      publicAPI.updatePolyData(facesToDraw, edges, ticks);
 
       // compute label world coords and text
-      publicAPI.updateTextData(facesToDraw, edgesToDraw, ticks, tickStrings);
+      publicAPI.updateTextData(facesToDraw, edges, ticks, tickStrings);
 
       // rebuild the texture only when force or changed bounds, face
       // visibility changes do to change the atlas
@@ -65,6 +70,7 @@ function vtkCustomCubeAxesActor(publicAPI, model) {
 const DEFAULT_VALUES = {
   ticksNo: 4,
   ticksScale: 1,
+  visibleLabels: [true, true],
 };
 
 export function extend(publicAPI, model, initialValues = {}) {
@@ -73,6 +79,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   vtkCubeAxesActor.extend(publicAPI, model, initialValues);
   macro.setGet(publicAPI, model, ["ticksNo"]);
   macro.setGet(publicAPI, model, ["ticksScale"]);
+  macro.setGetArray(publicAPI, model, ["visibleLabels"], 2);
   vtkCustomCubeAxesActor(publicAPI, model);
 }
 

--- a/fastapi/app/api/api_v1/endpoints/images.py
+++ b/fastapi/app/api/api_v1/endpoints/images.py
@@ -58,8 +58,6 @@ def create_plotly_image(plot_data: dict, format: str, details: dict):
     plot_data["layout"]["xaxis"]["automargin"] = True
     plot_data["layout"]["yaxis"]["automargin"] = True
     plot_data["layout"]["title"]["x"] = 0.5
-    # TODO: Find the best solution for legends that take up too much space
-    # plot_data["layout"]["showlegend"] = False
     plot_data["layout"].pop("name", None)
     plot_data["layout"].pop("frames", None)
     if details:

--- a/fastapi/app/api/api_v1/endpoints/variables.py
+++ b/fastapi/app/api/api_v1/endpoints/variables.py
@@ -126,14 +126,21 @@ async def generate_plot_data(bp, variable: str):
     raise HTTPException(status_code=400, detail="Unsupported plot type.")
 
 
-@router.get("/{variable_id}/timesteps")
+@router.get("/{variable_id}/timesteps/meta")
 async def get_timesteps(variable_id: str, girder_token: str = Header(None)):
     gc = get_girder_client(girder_token)
 
     item = gc.getItem(variable_id)
-    meta = item["meta"]
+    meta = {"steps": item["meta"]["timesteps"], "time": item["meta"]["time"]}
 
-    return {"steps": meta["timesteps"], "time": meta["time"]}
+    if x_range := item["meta"].get("x_range", None):
+        meta["x_range"] = x_range
+    if y_range := item["meta"].get("y_range", None):
+        meta["y_range"] = y_range
+    if color_range := item["meta"].get("color_range", None):
+        meta["color_range"] = color_range
+
+    return meta
 
 
 # variable_id => Girder item id for item used to represent the variable.


### PR DESCRIPTION
~Relies on #282 for docs to pass~ :white_check_mark:  

This PR provides the following - 

Features:
- UI toggles for showing or hiding plot details (axis labels/tick marks, scalar bar, legend visibility)
  - On ingest we use [`bpls`](https://adios2.readthedocs.io/en/latest/ecosystem/utilities.html#bpls-inspecting-data) and parse the string to grab the min/max ranges for the given variable and use this to update the metadata for that item. For mesh data we open the file to look at the mesh and find the min/max for each dimension.
- The option to apply a "global range" to the plots (uses the ranges for the completed run to prevent shifting axes/color range over time)
- New tooltip in the lower right that will display the ranges for any currently hidden data. This tooltip feature can also be toggled off.
- Improves the camera zoom/position for VTK.js plots so that plots take up as much space as possible and account for whether or not a given axes is visible.
  - Also adjusts the margins for Plotly plots as axes or title are toggled
- Moves the option to apply log scaling out of the Plotly mode bar (now no longer used for anything) and into the context menu

Fixes:
- Typos in some of the state values that were preventing data from being saved/accessed correctly
- Styling that did not account for the auto-save timestamp (when it appeared it was forcing items to overlap)
- Does not show grid lines for any VTK plots as these have been mentioned as unnecessary. This could potentially become another feature to be toggled if need be.

Cleanup:
- Removes unused code for a tooltip feature that is no longer used or needed.
- Hides the unused Plotly mode bar to keep plot behavior more consistent between types
- Added convenience function `localTimeStep`. This is meant to represent the time step that that particular plot instance should display (if that plot does not have data for that time step it should show the next previous step or the first step if there is no next previous).
- Added convenience function in the VTK plot component to do the computing of camera bounds (should happen on row/col add/remove, plot change, time step change, zoom change).

NOTES:
- The VTK plots do not have a title. They never have but this may be a problem with the option to turn all other information off now. This PR doesn't add that because as far as I can tell adding one is not straightforward.
- Users still have the option to set a range for a plot manually. If they do this will override the global setting they have selected.
- Applying the global range affects all of the data for the plots. There may be a need for for more fine-tuned control (e.g. just they y axis values) but I think that can be a future PR if needed.

![simple_plots](https://github.com/Kitware/eSimMon/assets/51238406/12d14db6-9f2f-4aa5-a848-7eef812378ab)
