### PR TITLE
Update libstdcxx-ng version

### DIFF
--- a/devops/docker/fastapi/Dockerfile
+++ b/devops/docker/fastapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:23.5.2-0 AS build
+FROM continuumio/miniconda3 AS build
 
 RUN apt-get update && apt-get install -y \
   curl \
@@ -70,7 +70,7 @@ RUN cd / && \
     -DVTK_MODULE_ENABLE_VTK_RenderingMatplotlib:STRING=YES && \
  ninja install
 
-FROM continuumio/miniconda3:23.5.2-0
+FROM continuumio/miniconda3
 
 RUN apt-get update && apt-get install -y \
   libgl1 && \
@@ -81,7 +81,8 @@ RUN conda install -c \
   python=3.9 \
   adios2 \
   gunicorn \
-  ffmpeg
+  ffmpeg \
+  libstdcxx-ng=13.1.0
 
 COPY --from=build /vtk /vtk
 


### PR DESCRIPTION
Latest coninuumio/miniconda3 image produces the error "ImportError: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found". Conda install libstdcxx-ng=13.1.0 to prevent this error.