### PR TITLE
Fast plots

### DIFF
--- a/client/src/components/core/App/script.js
+++ b/client/src/components/core/App/script.js
@@ -110,7 +110,7 @@ export default {
           return this.girderRest.get(`/folder/${response.data.folderId}`);
         })
         .then((response) => {
-          this.runId = response.data.parentId;
+          this.setRunId(response.data.parentId);
           return this.poll();
         });
     },
@@ -150,8 +150,8 @@ export default {
       if (this.paused) {
         return;
       }
-      var wait_ms = 500;
-      if (this.numReady >= this.gridSize) {
+      var wait_ms = this.syncSteps ? 500 : 100;
+      if (!this.syncSteps || this.numReady >= this.gridSize) {
         this.incrementTimeStep(false);
       }
       this.setTickWait(wait_ms);
@@ -194,7 +194,7 @@ export default {
       this.setRows(1);
       this.setGridSize(1);
       this.dataLoaded = false;
-      this.runId = null;
+      this.setRunId(null);
       this.location = null;
     },
 
@@ -235,6 +235,7 @@ export default {
 
   asyncComputed: {
     ...mapGetters({
+      syncSteps: "UI_SYNC_ANIMATION",
       drawerCollapsed: "UI_NAV_DRAWER_COLLAPSED",
       autoSavedViewDialog: "UI_AUTO_SAVE_DIALOG",
       paused: "UI_PAUSE_GALLERY",

--- a/client/src/components/widgets/ContextMenu/script.js
+++ b/client/src/components/widgets/ContextMenu/script.js
@@ -88,6 +88,9 @@ export default {
     isPlotly() {
       return this.itemInfo?.plotType === PlotType.Plotly;
     },
+    isStaticImage() {
+      return this.itemInfo?.plotType === PlotType.Image;
+    },
     plotDetails() {
       return (
         this.$store.getters[`${this.itemInfo?.id}/PLOT_DATA_COMPLETE`] || {}

--- a/client/src/components/widgets/ContextMenu/template.html
+++ b/client/src/components/widgets/ContextMenu/template.html
@@ -30,14 +30,14 @@
           <v-list-item-title> Average Over Time </v-list-item-title>
         </v-list-item>
       </v-list>
-      <v-divider v-if="!averaging" />
+      <v-divider v-if="!averaging && !isStaticImage" />
       <v-menu
         open-on-hover
         offset-y
         :position-x="offsetPos[0]"
         :position-y="offsetPos[1]"
         absolute
-        v-if="!averaging"
+        v-if="!averaging && !isStaticImage"
       >
         <template v-slot:activator="{ on, attrs }">
           <div v-bind="attrs" v-on="on">

--- a/client/src/components/widgets/PlotlyPlot/template.html
+++ b/client/src/components/widgets/PlotlyPlot/template.html
@@ -2,7 +2,7 @@
   <annotations v-if="enableRangeAnnotations" :text="annotationText()" top />
   <annotations
     v-if="enableStepAnnotations"
-    :text="[localTimeStep]"
+    :text="[`${localTimeStep}`]"
     bottom
     right
     size="large"

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -128,6 +128,22 @@ export default {
         }
       },
     },
+    // syncSteps: {
+    //   immediate: true,
+    //   handler(newVal, oldVal) {
+    //     if (newVal === oldVal) {
+    //       return;
+    //     }
+    //     if (this.plotFetcher && this.plotFetcher.initialized) {
+    //       this.plotFetcher.setSyncAnimation(newVal);
+    //       this.plotFetcher.setCurrentTimestep(this.localTimeStep, true);
+    //     }
+    //     this.setInitialLoad(true);
+    //     this.plotType = PlotType.None;
+    //     this.fetchTimeStepData(this.currentTimeStep);
+    //     // this.displayCurrentTimeStep();
+    //   },
+    // },
   },
 
   methods: {

--- a/client/src/components/widgets/Plots/script.js
+++ b/client/src/components/widgets/Plots/script.js
@@ -3,6 +3,7 @@ import { mapGetters, mapActions, mapMutations } from "vuex";
 import { decode } from "@msgpack/msgpack";
 import PlotlyPlot from "../PlotlyPlot";
 import VtkPlot from "../VTKPlot";
+import StaticImage from "../StaticImage";
 import { PlotType } from "../../../utils/constants";
 import { PlotFetcher } from "../../../utils/plotFetcher";
 
@@ -19,6 +20,7 @@ export default {
   components: {
     PlotlyPlot,
     VtkPlot,
+    StaticImage,
   },
 
   props: {
@@ -42,6 +44,9 @@ export default {
 
   computed: {
     ...mapGetters({
+      syncSteps: "UI_SYNC_ANIMATION",
+      loadingFromSaved: "VIEW_LOADING_FROM_SAVED",
+      viewTimeStep: "VIEW_SAVED_TIME_STEP",
       currentTimeStep: "VIEW_TIME_STEP",
       minTimeStep: "VIEW_MIN_TIME_STEP",
       maxTimeStep: "VIEW_MAX_TIME_STEP",
@@ -80,10 +85,6 @@ export default {
     currentTimeStep: {
       immediate: true,
       handler() {
-        // First display the updated timestep
-        if (this.plotFetcher && this.plotFetcher.initialized) {
-          this.plotFetcher.setCurrentTimestep(this.currentTimeStep, true);
-        }
         if (!this.initialDataLoaded) {
           this.displayCurrentTimeStep();
         }
@@ -100,16 +101,20 @@ export default {
             this.itemId,
             (itemId) =>
               this.callFastEndpoint(`variables/${itemId}/timesteps/meta`),
-            (itemId, timestep) =>
+            (itemId, timestep, asImage) =>
               this.callFastEndpoint(
-                `variables/${itemId}/timesteps/${timestep}/plot`,
+                `variables/${itemId}/timesteps/${timestep}/plot?as_image=${asImage}`,
                 { responseType: "blob" },
               ),
-            (response, timeStep, itemId) =>
-              this.resolveTimeStepData(response, timeStep, itemId),
+            (response, timeStep) =>
+              this.resolveTimeStepData(response, timeStep),
+            this.syncSteps,
           );
           this.plotFetcher.initialize().then(() => {
-            this.plotFetcher.setCurrentTimestep(this.currentTimeStep, true);
+            const step = this.loadingFromSaved
+              ? this.viewTimeStep
+              : this.currentTimeStep;
+            this.plotFetcher.setCurrentTimestep(step, true);
             this.loadVariable();
           });
         }
@@ -193,7 +198,10 @@ export default {
      */
     resolveTimeStepData: function (response, timeStep) {
       const reader = new FileReader();
-      if (response.type === "application/msgpack") {
+      if (response.type.includes("image/")) {
+        reader.readAsDataURL(response);
+        this.plotType = PlotType.Image;
+      } else if (response.type === "application/msgpack") {
         reader.readAsArrayBuffer(response);
         this.plotType = PlotType.VTK;
       } else {
@@ -208,7 +216,16 @@ export default {
         reader.onload = () => {
           let img;
           const ltsd = this.loadedTimeStepData;
-          if (this.plotType === PlotType.VTK) {
+          if (this.plotType === PlotType.Image) {
+            this.setLoadedTimeStepData([
+              ...ltsd,
+              {
+                timestep: timeStep,
+                url: reader.result,
+                type: PlotType.Image,
+              },
+            ]);
+          } else if (this.plotType === PlotType.VTK) {
             img = decode(reader.result);
             this.$refs[`${this.row}-${this.col}`].addRenderer(img);
             if (!this.isTimeStepLoaded(timeStep)) {
@@ -274,6 +291,7 @@ export default {
       const response = await this.plotFetcher.fastEndpointFn(
         this.itemId,
         firstAvailableStep,
+        !this.syncSteps,
       );
       await this.plotFetcher.fetchTimeStepFn(response, firstAvailableStep);
 

--- a/client/src/components/widgets/Plots/template.html
+++ b/client/src/components/widgets/Plots/template.html
@@ -12,12 +12,20 @@
       :timeAverage="timeAverage"
       :plotDataLoaded="plotDataLoaded"
       :plotXAxis="plotXAxis"
+      :plotFetcher="plotFetcher"
     />
     <vtk-plot
       :ref="row+'-'+col"
       v-if="plotType === 'vtk'"
       :itemId="itemId"
       :plotXAxis="plotXAxis"
+      :plotFetcher="plotFetcher"
+    />
+    <static-image
+      :ref="row+'-'+col"
+      v-if="plotType === 'image'"
+      :itemId="itemId"
+      :plotFetcher="plotFetcher"
     />
     <div class="plot">
       <v-icon v-if="!plotType" large> input </v-icon>

--- a/client/src/components/widgets/SettingsPanel/script.js
+++ b/client/src/components/widgets/SettingsPanel/script.js
@@ -38,6 +38,7 @@ export default {
       toggleLegend: "UI_TOGGLE_LEGEND",
     }),
     ...mapMutations({
+      setSyncSteps: "UI_SYNC_ANIMATION_SET",
       setPaused: "UI_PAUSE_GALLERY_SET",
       setLoadDialogVisible: "UI_SHOW_LOAD_DIALOG_SET",
       setSaveDialogVisible: "UI_SHOW_SAVE_DIALOG_SET",
@@ -59,6 +60,7 @@ export default {
 
   computed: {
     ...mapGetters({
+      syncSteps: "UI_SYNC_ANIMATION",
       enableStepAnnotations: "UI_SHOW_STEP_ANNOTATION",
       enableRangeAnnotations: "UI_SHOW_RANGE_ANNOTATION",
       showLegend: "UI_SHOW_LEGEND",
@@ -164,6 +166,14 @@ export default {
       },
       set(val) {
         this.setStepAnnotationsEnabled(val);
+      },
+    },
+    stepSync: {
+      get() {
+        return this.syncSteps;
+      },
+      set(val) {
+        this.setSyncSteps(val);
       },
     },
   },

--- a/client/src/components/widgets/SettingsPanel/script.js
+++ b/client/src/components/widgets/SettingsPanel/script.js
@@ -79,6 +79,7 @@ export default {
       run: "VIEWS_RUN_ID",
       simulation: "VIEWS_SIMULATION",
       step: "VIEW_TIME_STEP",
+      initialDataLoaded: "VIEW_INITIAL_LOAD",
     }),
     zoomSync: {
       get() {

--- a/client/src/components/widgets/SettingsPanel/template.html
+++ b/client/src/components/widgets/SettingsPanel/template.html
@@ -33,6 +33,7 @@
                 <v-switch
                   v-model="stepSync"
                   label="Sync animation"
+                  :disabled="!initialDataLoaded"
                   hide-details
                 />
               </div>

--- a/client/src/components/widgets/SettingsPanel/template.html
+++ b/client/src/components/widgets/SettingsPanel/template.html
@@ -30,6 +30,20 @@
           <v-tooltip left bottom>
             <template v-slot:activator="{on, attrs}">
               <div v-on="on" v-bind="attrs">
+                <v-switch
+                  v-model="stepSync"
+                  label="Sync animation"
+                  hide-details
+                />
+              </div>
+            </template>
+            <p class="mb-0">Syncronize time step animation</p>
+          </v-tooltip>
+        </v-col>
+        <v-col sm="6">
+          <v-tooltip left bottom>
+            <template v-slot:activator="{on, attrs}">
+              <div v-on="on" v-bind="attrs">
                 <v-switch v-model="zoomSync" label="Sync zoom" hide-details />
               </div>
             </template>
@@ -37,7 +51,9 @@
             <p class="mb-0">plots with the same x-axis.</p>
           </v-tooltip>
         </v-col>
-        <v-col sm="6">
+      </v-row>
+      <v-row>
+        <v-col sm="12">
           <v-tooltip left bottom>
             <template v-slot:activator="{on, attrs}">
               <div v-on="on" v-bind="attrs">
@@ -50,20 +66,6 @@
             </template>
             <p class="mb-0">Double-click on a point on a time</p>
             <p class="mb-0">plot to jump to that time step.</p>
-          </v-tooltip>
-        </v-col>
-      </v-row>
-      <v-subheader> Mode </v-subheader>
-      <v-divider />
-      <v-row>
-        <v-col sm="12">
-          <v-tooltip left bottom>
-            <template v-slot:activator="{on, attrs}">
-              <div v-on="on" v-bind="attrs">
-                <v-switch label="View completed runs" hide-details disabled />
-              </div>
-            </template>
-            <span>This feature is not currently enabled.</span>
           </v-tooltip>
         </v-col>
       </v-row>

--- a/client/src/components/widgets/StaticImage/index.vue
+++ b/client/src/components/widgets/StaticImage/index.vue
@@ -1,0 +1,3 @@
+<script src="./script.js" />
+<style src="../../../scss/gallery.scss" lang="scss" />
+<template src="./template.html" />

--- a/client/src/components/widgets/StaticImage/script.js
+++ b/client/src/components/widgets/StaticImage/script.js
@@ -1,0 +1,102 @@
+import { mapGetters, mapMutations } from "vuex";
+import Annotations from "../Annotations";
+import { PlotFetcher } from "../../../utils/plotFetcher";
+import { nextAvailableTimeStep } from "../../../utils/helpers";
+
+export default {
+  name: "StaticImage",
+  inject: ["girderRest", "fastRestUrl"],
+
+  components: {
+    Annotations,
+  },
+
+  props: {
+    itemId: {
+      type: String,
+      required: true,
+    },
+    plotFetcher: {
+      type: PlotFetcher,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      imageURL: "",
+      availableTimeSteps: [],
+      localTimeStep: 1,
+      nextTimeStep: 1,
+    };
+  },
+
+  computed: {
+    ...mapGetters({
+      enableStepAnnotations: "UI_SHOW_STEP_ANNOTATION",
+      numReady: "VIEW_NUM_READY",
+      currentTimeStep: "VIEW_TIME_STEP",
+      numCols: "VIEWS_COLUMNS",
+      numRows: "VIEWS_ROWS",
+    }),
+    itemTimeSteps() {
+      return (
+        this.$store.getters[`${this.itemId}/PLOT_AVAILABLE_TIME_STEPS`] || []
+      );
+    },
+    loadedTimeStepData() {
+      return this.$store.getters[`${this.itemId}/PLOT_LOADED_TIME_STEPS`] || [];
+    },
+  },
+
+  methods: {
+    ...mapMutations({
+      updateNumReady: "VIEW_NUM_READY_SET",
+    }),
+    react() {
+      this.imageURL = this.loadedTimeStepData.find(
+        (img) => img.timestep == this.nextTimeStep,
+      )?.url;
+      this.updateNumReady(this.numReady + 1);
+      this.$nextTick(this.recomputeRatio);
+    },
+    recomputeRatio() {
+      this.$nextTick(() => {
+        const { width, height } = this.$el.getBoundingClientRect();
+        const el = document.getElementById(`static-${this.itemId}`);
+        if (width < height) {
+          const newHeight = (el.naturalHeight / el.naturalWidth) * width;
+          el.style.height = newHeight;
+          el.style.width = "auto";
+        } else {
+          const newWidth = height / (el.naturalHeight / el.naturalWidth);
+          el.style.width = newWidth;
+          el.style.height = "auto";
+        }
+      });
+    },
+  },
+
+  watch: {
+    numCols() {
+      this.$nextTick(this.recomputeRatio);
+    },
+    numRows() {
+      this.$nextTick(this.recomputeRatio);
+    },
+    loadedTimeStepData(loaded) {
+      this.availableTimeSteps =
+        loaded.map((d) => d.timestep).sort((a, b) => a - b) || [];
+    },
+    currentTimeStep(step) {
+      this.localTimeStep = nextAvailableTimeStep(step, this.itemTimeSteps);
+      this.plotFetcher.setCurrentTimestep(this.localTimeStep, true);
+      this.nextTimeStep = nextAvailableTimeStep(step, this.availableTimeSteps);
+    },
+    availableTimeSteps(ats) {
+      // Continue displaying the time step closest to the
+      // requested step if the requested step is unavailable.
+      this.nextTimeStep = nextAvailableTimeStep(this.currentTimeStep, ats);
+    },
+  },
+};

--- a/client/src/components/widgets/StaticImage/template.html
+++ b/client/src/components/widgets/StaticImage/template.html
@@ -1,0 +1,10 @@
+<div class="pt-1 d-flex justify-center static">
+  <img :id="'static-'+itemId" :src="imageURL" />
+  <annotations
+    v-if="enableStepAnnotations"
+    :text="[`${nextTimeStep}`]"
+    bottom
+    right
+    size="large"
+  />
+</div>

--- a/client/src/components/widgets/VTKPlot/template.html
+++ b/client/src/components/widgets/VTKPlot/template.html
@@ -3,7 +3,7 @@
   <annotations v-if="enableRangeAnnotations" :text="annotationText()" top />
   <annotations
     v-if="enableStepAnnotations"
-    :text="[localTimeStep]"
+    :text="[`${localTimeStep}`]"
     bottom
     right
     size="large"

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -300,3 +300,12 @@ html {
   transform: rotate(270deg);
   transform-origin: (0 0);
 }
+
+.static {
+  height: inherit;
+  max-width: inherit;
+  img {
+    box-sizing: content-box;
+    max-width: 100%;
+  }
+}

--- a/client/src/store/ui.js
+++ b/client/src/store/ui.js
@@ -34,6 +34,7 @@ export default {
     rangeAnnotations: true,
     drawerCollapsed: false,
     stepAnnotations: true,
+    syncAnimation: false,
   },
   getters: {
     UI_AUTO_SAVE_DIALOG(state) {
@@ -122,6 +123,9 @@ export default {
     UI_SHOW_STEP_ANNOTATION(state) {
       return state.stepAnnotations;
     },
+    UI_SYNC_ANIMATION(state) {
+      return state.syncAnimation;
+    },
   },
   mutations: {
     UI_AUTO_SAVE_DIALOG_SET(state, val) {
@@ -195,6 +199,9 @@ export default {
     },
     UI_SHOW_STEP_ANNOTATION_SET(state, val) {
       state.stepAnnotations = val;
+    },
+    UI_SYNC_ANIMATION_SET(state, val) {
+      state.syncAnimation = val;
     },
   },
   actions: {

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -4,5 +4,6 @@ export const PlotType = {
   Mesh: "mesh-colormap",
   ColorMap: "colormap",
   Scatter: "scatter",
+  Image: "image",
   None: null,
 };

--- a/client/src/utils/helpers.js
+++ b/client/src/utils/helpers.js
@@ -11,3 +11,14 @@ export function extractRange(array) {
   }
   return [minValue, maxValue];
 }
+
+export function nextAvailableTimeStep(requested, available) {
+  let timeStep = requested;
+  if (!available.find((v) => v === timeStep)) {
+    let idx = available.findIndex((v) => v >= timeStep);
+    idx = idx === -1 ? available.length : idx;
+    idx = Math.max((idx -= 1), 0);
+    timeStep = available[idx];
+  }
+  return timeStep;
+}

--- a/client/tests/plotFetcher.spec.ts
+++ b/client/tests/plotFetcher.spec.ts
@@ -49,9 +49,10 @@ const logResponse = (promise?: Promise<any>) => {
 test('multi-fetcher', () => {
   return new Promise<void>((resolve) => {
     const N_FETCHERS = 10;
+    const sync = false;
     const fetchers: PlotFetcher[] = [];
     for (let i = 0; i < N_FETCHERS; ++i) {
-      fetchers.push(new PlotFetcher(i.toString(), endpointFn, fastEndpointFn, fetchTimeStepFn));
+      fetchers.push(new PlotFetcher(i.toString(), endpointFn, fastEndpointFn, fetchTimeStepFn, sync));
     }
 
     Promise.all(fetchers.map(fetcher => fetcher.initialize())).then(() => {

--- a/devops/docker/fastapi/Dockerfile
+++ b/devops/docker/fastapi/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN conda install -c \
   conda-forge \
-  python=3.9 \
+  python=3.10 \
   cmake=3.26.4 \
   ninja \
   mako
@@ -78,7 +78,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN conda install -c \
   conda-forge \
-  python=3.9 \
+  python=3.10 \
   adios2 \
   gunicorn \
   ffmpeg \
@@ -92,7 +92,7 @@ COPY fastapi/requirements.txt /app/requirements.txt
 
 RUN pip install -r /app/requirements.txt
 
-ENV PYTHONPATH=/vtk/lib/python3.9/site-packages
+ENV PYTHONPATH=/vtk/lib/python3.10/site-packages
 
 ENV LD_LIBRARY_PATH=/vtk/lib:/mesa/lib/x86_64-linux-gnu/
 

--- a/fastapi/app/api/api_v1/endpoints/images.py
+++ b/fastapi/app/api/api_v1/endpoints/images.py
@@ -166,7 +166,7 @@ def create_plotly_image(plot_data: dict, format: str, plot_details: PlotDetails)
     # Get image as bytes
     fig = go.Figure(plot_data["data"], plot_data["layout"])
     output_file = tempfile.NamedTemporaryFile(suffix=f".{format}", delete=False)
-    fig.write_image(output_file.name, format="png")
+    fig.write_image(output_file.name, format=format)
     return _convert_image(output_file, format, plot_details)
 
 


### PR DESCRIPTION
Adds:
- When new data is ingested a "default" movie is produced when the run is complete. The images used in this movie generation are now also saved so that when we animate the dashboard in "fast" mode we stream the static images instead of dynamically generating the plot for each time step.
- Static images are now also ingested if they are listed in the `variables.json` file. The path for the attribute should be updated to point to the image instead of the BP file. The image is expected to be named `attribute_name`.`ext`, where `attribute_name` is the same as the string provided to the `attribute_name` key.
- Client-side support for static images has been added.
    - If the requested variable does not exist in that time step's BP file or no BP file exists for that time step we look for a static image instead and return that if found.
    - If we ingest a static image that is the image served in both standard and fast-play mode.

Needs:
- [ ] Support toggling between the modes. Currently users can only select the mode before loading data.
    - [ ] Test toggling thoroughly, including loading auto-save/load view/load template in either mode
- [ ] Support movie generation and image download for static images.
    - [ ] No `Save As...` option for static images